### PR TITLE
feat: add cache-busting and update team names

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>KPOP Protocol</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
+  <title>KPOP Protocol</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <script>
+    window.assetVersion = Date.now();
+    const style = document.createElement('link');
+    style.rel = 'stylesheet';
+    style.href = `style.css?v=${window.assetVersion}`;
+    document.head.appendChild(style);
+  </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
 </head>
@@ -72,6 +81,11 @@
       <p data-i18n="footer_text">&copy; 2026 KPOP Protocol. 본 사이트의 정보는 투자 권유가 아닙니다.</p>
     </footer>
 
-  <script type="module" src="main.js"></script>
+  <script>
+    const script = document.createElement('script');
+    script.type = 'module';
+    script.src = `main.js?v=${window.assetVersion}`;
+    document.body.appendChild(script);
+  </script>
 </body>
 </html>

--- a/team.html
+++ b/team.html
@@ -3,9 +3,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
     <title>KPOP Protocol 팀</title>
-    <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <script>
+    window.assetVersion = Date.now();
+    const style = document.createElement('link');
+    style.rel = 'stylesheet';
+    style.href = `style.css?v=${window.assetVersion}`;
+    document.head.appendChild(style);
+  </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
 </head>
@@ -35,18 +44,18 @@
   <section class="team-section">
     <div class="team-grid">
         <div class="member">
-          <img src="https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?auto=format&fit=crop&w=200&q=80" alt="Alex Carter">
-          <h3>Alex Carter</h3>
+          <img src="https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?auto=format&fit=crop&w=200&q=80" alt="Liam Johnson">
+          <h3>Liam Johnson</h3>
           <p data-i18n="role_ceo">CEO &amp; Co-Founder</p>
         </div>
         <div class="member">
-          <img src="https://images.unsplash.com/photo-1531123897727-8f129e1688ce?auto=format&fit=crop&w=200&q=80" alt="Emily Wilson">
-          <h3>Emily Wilson</h3>
+          <img src="https://images.unsplash.com/photo-1531123897727-8f129e1688ce?auto=format&fit=crop&w=200&q=80" alt="Olivia Smith">
+          <h3>Olivia Smith</h3>
           <p data-i18n="role_cto">CTO</p>
         </div>
         <div class="member">
-          <img src="https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?auto=format&fit=crop&w=200&q=80" alt="Michael Brown">
-          <h3>Michael Brown</h3>
+          <img src="https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?auto=format&fit=crop&w=200&q=80" alt="Noah Davis">
+          <h3>Noah Davis</h3>
           <p data-i18n="role_lead">Lead Blockchain Engineer</p>
         </div>
     </div>
@@ -56,6 +65,11 @@
       <p data-i18n="footer_text">&copy; 2026 KPOP Protocol. 본 사이트의 정보는 투자 권유가 아닙니다.</p>
     </footer>
 
-  <script type="module" src="main.js"></script>
+  <script>
+    const script = document.createElement('script');
+    script.type = 'module';
+    script.src = `main.js?v=${window.assetVersion}`;
+    document.body.appendChild(script);
+  </script>
 </body>
 </html>

--- a/whitepaper.html
+++ b/whitepaper.html
@@ -3,9 +3,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
     <title>KPOP Protocol 백서</title>
-    <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <script>
+    window.assetVersion = Date.now();
+    const style = document.createElement('link');
+    style.rel = 'stylesheet';
+    style.href = `style.css?v=${window.assetVersion}`;
+    document.head.appendChild(style);
+  </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
   <style>
@@ -227,7 +236,12 @@
   <footer class="footer">
     <p data-i18n="footer_text">&copy; 2026 KPOP Protocol. 본 사이트의 정보는 투자 권유가 아닙니다.</p>
   </footer>
-  <script type="module" src="main.js"></script>
+  <script>
+    const script = document.createElement('script');
+    script.type = 'module';
+    script.src = `main.js?v=${window.assetVersion}`;
+    document.body.appendChild(script);
+  </script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- prevent cached CSS/JS by appending timestamps and disabling caching headers
- update team member names to American-style names

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d9d9e18608327925c9296a13724a3