### PR TITLE
Refine responsive layout and unify fancy titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,8 @@
 </head>
 <body data-page="index">
   <nav class="navbar">
-    <div class="logo">KPOP Protocol</div>
+    <a href="index.html" class="logo">KPOP Protocol</a>
+    <button class="menu-toggle" aria-label="Toggle navigation"><i class="fa-solid fa-bars"></i></button>
     <ul class="nav-links">
       <li><a href="#about"><i class="fa-solid fa-circle-info"></i><span data-i18n="nav_about">소개</span></a></li>
       <li><a href="#technology"><i class="fa-solid fa-microchip"></i><span data-i18n="nav_technology">기술</span></a></li>

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 gsap.registerPlugin(ScrollTrigger);
 
 class KPPFancyTitle extends HTMLElement {
-  static get observedAttributes() { return ['text']; }
+  static get observedAttributes() { return ['text', 'size']; }
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
@@ -14,12 +14,13 @@ class KPPFancyTitle extends HTMLElement {
   }
   render() {
     const text = this.getAttribute('text') || '';
+    const size = this.getAttribute('size') || 'large';
     this.shadowRoot.innerHTML = `
       <style>
         :host { display: inline-block; }
         h1 {
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(2.5rem, 8vw, 4rem);
+          font-size: ${size === 'medium' ? '1.8rem' : 'clamp(2.5rem, 8vw, 4rem)'};
           margin: 0;
           position: relative;
           background: linear-gradient(45deg,#ff0080,#ffcd00,#00f0ff);
@@ -51,6 +52,29 @@ class KPPFancyTitle extends HTMLElement {
 }
 
 customElements.define('kpp-fancy-title', KPPFancyTitle);
+
+function applyFancyTitles() {
+  document.querySelectorAll('h1').forEach(h1 => {
+    if (h1.closest('kpp-fancy-title')) return;
+    const fancy = document.createElement('kpp-fancy-title');
+    fancy.setAttribute('size', 'large');
+    fancy.setAttribute('text', h1.textContent.trim());
+    if (h1.className) fancy.className = h1.className;
+    if (h1.dataset.i18n) fancy.setAttribute('data-i18n', h1.dataset.i18n);
+    h1.replaceWith(fancy);
+  });
+  document.querySelectorAll('h2').forEach(h2 => {
+    const fancy = document.createElement('kpp-fancy-title');
+    fancy.setAttribute('size', 'medium');
+    fancy.setAttribute('text', h2.textContent.trim());
+    if (h2.className) fancy.className = h2.className;
+    if (h2.id) fancy.id = h2.id;
+    if (h2.dataset.i18n) fancy.setAttribute('data-i18n', h2.dataset.i18n);
+    h2.replaceWith(fancy);
+  });
+}
+
+applyFancyTitles();
 
 document.querySelectorAll('section, .wp-section').forEach(section => {
   gsap.from(section, {
@@ -210,6 +234,13 @@ setLanguage(currentLang);
 const select = document.querySelector('.lang-select');
 if (select) {
   select.addEventListener('change', e => setLanguage(e.target.value));
+}
+
+const menuToggle = document.querySelector('.menu-toggle');
+if (menuToggle) {
+  menuToggle.addEventListener('click', () => {
+    document.querySelector('.navbar').classList.toggle('open');
+  });
 }
 
 const hero = document.querySelector('.hero');

--- a/style.css
+++ b/style.css
@@ -15,6 +15,11 @@ html, body {
   font-size: 15px;
   line-height: 1.6;
   color-scheme: dark;
+  overflow-x: hidden;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
 }
 
 html {
@@ -44,6 +49,7 @@ html {
   list-style: none;
   display: flex;
   gap: 1rem;
+  flex-wrap: wrap;
   margin: 0;
   padding: 0;
 }
@@ -73,6 +79,15 @@ html {
   border-radius: 4px;
   padding: 0.2rem 0.4rem;
   margin-left: 1rem;
+}
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--fg);
+  font-size: 1.5rem;
+  margin-left: auto;
 }
 
 .hero {
@@ -190,14 +205,23 @@ ul, ol {
 
 @media (max-width: 600px) {
   .navbar {
-    flex-direction: column;
-    align-items: flex-start;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  .menu-toggle {
+    display: block;
   }
 
   .navbar .nav-links {
     flex-direction: column;
     width: 100%;
     gap: 0.5rem;
+    display: none;
+  }
+
+  .navbar.open .nav-links {
+    display: flex;
   }
 
   .hero {

--- a/team.html
+++ b/team.html
@@ -20,7 +20,8 @@
 </head>
 <body data-page="team">
   <nav class="navbar">
-    <div class="logo">KPOP Protocol</div>
+    <a href="index.html" class="logo">KPOP Protocol</a>
+    <button class="menu-toggle" aria-label="Toggle navigation"><i class="fa-solid fa-bars"></i></button>
     <ul class="nav-links">
       <li><a href="index.html#about"><i class="fa-solid fa-circle-info"></i><span data-i18n="nav_about">소개</span></a></li>
       <li><a href="index.html#technology"><i class="fa-solid fa-microchip"></i><span data-i18n="nav_technology">기술</span></a></li>
@@ -37,7 +38,7 @@
   </nav>
 
   <header class="hero small">
-    <h1 data-i18n="team_hero_title">팀 소개</h1>
+    <h1 class="hero-title" data-i18n="team_hero_title">팀 소개</h1>
     <p data-i18n="team_hero_subtitle">KPOP Protocol을 이끄는 전문가들</p>
   </header>
 

--- a/whitepaper.html
+++ b/whitepaper.html
@@ -27,7 +27,8 @@
 </head>
 <body data-page="whitepaper">
   <nav class="navbar">
-    <div class="logo">KPOP Protocol</div>
+    <a href="index.html" class="logo">KPOP Protocol</a>
+    <button class="menu-toggle" aria-label="Toggle navigation"><i class="fa-solid fa-bars"></i></button>
     <ul class="nav-links">
       <li><a href="index.html#about"><i class="fa-solid fa-circle-info"></i><span data-i18n="nav_about">소개</span></a></li>
       <li><a href="index.html#technology"><i class="fa-solid fa-microchip"></i><span data-i18n="nav_technology">기술</span></a></li>


### PR DESCRIPTION
## Summary
- Make top-left logo link back to home and add a mobile-friendly menu toggle
- Apply `kpp-fancy-title` across headings with size options for consistent styling
- Improve responsiveness with overflow fixes, nav wrapping, and hamburger menu styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689da2dea2c48327a3c99254467b7c82