### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
         <option value="en">🇺🇸</option>
         <option value="zh">🇨🇳</option>
       </select>
+    <button class="theme-toggle" aria-label="Toggle theme"><i class="fa-solid fa-moon"></i></button>
   </nav>
 
   <header class="hero">

--- a/main.js
+++ b/main.js
@@ -1,5 +1,8 @@
 gsap.registerPlugin(ScrollTrigger);
 
+const savedTheme = localStorage.getItem('theme') || 'light';
+document.documentElement.setAttribute('data-theme', savedTheme);
+
 class KPPFancyTitle extends HTMLElement {
   static get observedAttributes() { return ['text', 'size']; }
   constructor() {
@@ -154,6 +157,23 @@ const menuToggle = document.querySelector('.menu-toggle');
 if (menuToggle) {
   menuToggle.addEventListener('click', () => {
     document.querySelector('.navbar').classList.toggle('open');
+  });
+}
+
+const themeBtn = document.querySelector('.theme-toggle');
+if (themeBtn) {
+  const setIcon = theme => {
+    themeBtn.innerHTML = theme === 'dark'
+      ? '<i class="fa-solid fa-sun"></i>'
+      : '<i class="fa-solid fa-moon"></i>';
+  };
+  setIcon(savedTheme);
+  themeBtn.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme');
+    const next = current === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+    setIcon(next);
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -7,6 +7,12 @@
   --accent: #ff4081;
 }
 
+:root[data-theme='dark'] {
+  --bg: #121212;
+  --fg: #e0e0e0;
+  --accent: #ff4081;
+}
+
 html, body {
   margin: 0;
   padding: 0;
@@ -17,6 +23,10 @@ html, body {
   line-height: 1.6;
   color-scheme: light;
   overflow-x: hidden;
+}
+
+html[data-theme='dark'], html[data-theme='dark'] body {
+  color-scheme: dark;
 }
 
 *, *::before, *::after {
@@ -40,6 +50,10 @@ html {
   backdrop-filter: blur(5px);
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   z-index: 10;
+}
+
+[data-theme='dark'] .navbar {
+  background: rgba(0,0,0,0.8);
 }
 
 .navbar .logo {
@@ -81,6 +95,15 @@ html {
   border-radius: 4px;
   padding: 0.2rem 0.4rem;
   margin-left: 1rem;
+}
+
+.theme-toggle {
+  background: none;
+  border: none;
+  color: var(--fg);
+  font-size: 1.2rem;
+  margin-left: 0.5rem;
+  cursor: pointer;
 }
 
 .menu-toggle {
@@ -335,6 +358,11 @@ ul, ol {
   padding: 1rem;
   background: rgba(0,0,0,0.05);
   border-radius: 8px;
+}
+
+[data-theme='dark'] .wp-section,
+[data-theme='dark'] .footer {
+  background: rgba(255,255,255,0.05);
 }
 
 .wp-section kpp-fancy-title {


### PR DESCRIPTION
## Summary
- add dark mode toggle button with persistent preference
- style site for light and dark themes
- wire theme toggle logic in main script

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f632996c83278502e8b0d0f6cc37