### PR TITLE
Add locale consistency check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ Any web server (e.g., Nginx, Apache, GitHub Pages) can host the built site for p
 
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+Before committing changes to translation files in `locales/`, run the locale consistency check:
+
+```bash
+node scripts/check-locales.js
+```
+
+This script ensures every locale file has the same keys as `locales/en.json` and reports any missing or extra entries.

--- a/scripts/check-locales.js
+++ b/scripts/check-locales.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const localesDir = path.join(__dirname, '..', 'locales');
+const baseFile = 'en.json';
+const basePath = path.join(localesDir, baseFile);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+const baseData = readJson(basePath);
+const baseKeys = new Set(Object.keys(baseData));
+const files = fs.readdirSync(localesDir).filter(f => f.endsWith('.json'));
+
+let hasDiscrepancies = false;
+
+files.forEach(file => {
+  if (file === baseFile) return;
+  const localeData = readJson(path.join(localesDir, file));
+  const localeKeys = new Set(Object.keys(localeData));
+
+  const missing = [...baseKeys].filter(k => !localeKeys.has(k));
+  const extra = [...localeKeys].filter(k => !baseKeys.has(k));
+
+  if (missing.length || extra.length) {
+    hasDiscrepancies = true;
+    console.log(`\nDiscrepancies in ${file}:`);
+    if (missing.length) console.log('  Missing keys:', missing.join(', '));
+    if (extra.length) console.log('  Extra keys:', extra.join(', '));
+  } else {
+    console.log(`${file} matches ${baseFile}`);
+  }
+});
+
+if (!hasDiscrepancies) {
+  console.log('All locale files match', baseFile);
+} else {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add a Node.js script to verify translation files match the English keys
- document how to run the locale check before committing translation updates

## Testing
- `node scripts/check-locales.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3bfaea9ec8327a69ce77f3a6ff427