### PR TITLE
Add KPP token symbol and favicon

### DIFF
--- a/assets/kpp-symbol.svg
+++ b/assets/kpp-symbol.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="48" fill="#ff4081"/>
+  <text x="50" y="60" font-size="45" font-family="Arial, sans-serif" text-anchor="middle" fill="#ffffff">KPP</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
   <title>KPOP Protocol</title>
+  <link rel="icon" type="image/svg+xml" href="assets/kpp-symbol.svg">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <script>
     window.assetVersion = Date.now();
@@ -20,7 +21,7 @@
 </head>
 <body data-page="index">
   <nav class="navbar">
-    <a href="index.html" class="logo">KPOP Protocol</a>
+    <a href="index.html" class="logo"><img src="assets/kpp-symbol.svg" alt="KPP logo">KPOP Protocol</a>
     <button class="menu-toggle" aria-label="Toggle navigation"><i class="fa-solid fa-bars"></i></button>
     <ul class="nav-links">
       <li><a href="#about"><i class="fa-solid fa-circle-info"></i><span data-i18n="nav_about">소개</span></a></li>

--- a/style.css
+++ b/style.css
@@ -51,6 +51,14 @@ html {
 .navbar .logo {
   font-family: 'Montserrat', sans-serif;
   font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.navbar .logo img {
+  width: 24px;
+  height: 24px;
 }
 
 .navbar .nav-links {


### PR DESCRIPTION
## Summary
- Introduce KPP token symbol as scalable SVG asset
- Display logo image in navigation and set as site favicon
- Style navigation logo for symbol

## Testing
- `npm test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f67f10bc8327aea7b5543dee726b