### PR TITLE
Fix logo size on load and update SVG text

### DIFF
--- a/assets/kpp-symbol.svg
+++ b/assets/kpp-symbol.svg
@@ -6,5 +6,5 @@
     </radialGradient>
   </defs>
   <circle cx="50" cy="50" r="48" fill="url(#grad)" stroke="#ffffff" stroke-width="2"/>
-  <text x="50" y="50" font-size="45" font-family="Arial, sans-serif" text-anchor="middle" dominant-baseline="middle" fill="#ffffff">KPP</text>
+    <text x="50" y="50" font-size="25" font-family="Arial, sans-serif" text-anchor="middle" dominant-baseline="middle" fill="#ffffff">KPOP</text>
 </svg>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 </head>
 <body data-page="index">
   <nav class="navbar">
-    <a href="index.html" class="logo"><img src="assets/kpp-symbol.svg" alt="KPP logo">KPOP Protocol</a>
+      <a href="index.html" class="logo"><img src="assets/kpp-symbol.svg" alt="KPP logo" width="24" height="24">KPOP Protocol</a>
     <button class="menu-toggle" aria-label="Toggle navigation"><i class="fa-solid fa-bars"></i></button>
     <ul class="nav-links">
       <li><a href="#about"><i class="fa-solid fa-circle-info"></i><span data-i18n="nav_about">소개</span></a></li>


### PR DESCRIPTION
## Summary
- Prevent oversized logo on initial page refresh by setting image dimensions
- Update `kpp-symbol.svg` text to "KPOP" with smaller font size

## Testing
- `npm test` *(fails: Couldn't download compiler version list; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4055d1afc832785afbb33ab2b7967