### PR TITLE
Align KPOP symbol with corporate identity

### DIFF
--- a/assets/kpp-symbol.svg
+++ b/assets/kpp-symbol.svg
@@ -1,10 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
   <defs>
-    <radialGradient id="grad" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#ff80ab"/>
-      <stop offset="100%" stop-color="#ff4081"/>
-    </radialGradient>
+    <linearGradient id="brandGradient" x1="100%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f6d365"/>
+      <stop offset="33%" stop-color="#fda085"/>
+      <stop offset="66%" stop-color="#a1c4fd"/>
+      <stop offset="100%" stop-color="#c2e9fb"/>
+    </linearGradient>
   </defs>
-  <circle cx="50" cy="50" r="48" fill="url(#grad)" stroke="#ffffff" stroke-width="2"/>
-    <text x="50" y="50" font-size="25" font-family="Arial, sans-serif" text-anchor="middle" dominant-baseline="middle" fill="#ffffff">KPOP</text>
+  <circle cx="50" cy="50" r="48" fill="url(#brandGradient)" stroke="#ffffff" stroke-width="2"/>
+  <text x="50" y="50" font-size="25" font-family="Montserrat, sans-serif" text-anchor="middle" dominant-baseline="middle" fill="#222222">KPOP</text>
 </svg>


### PR DESCRIPTION
## Summary
- apply hero-style multicolor gradient to symbol
- update symbol text to "KPOP" using corporate color

## Testing
- `npm test` *(fails: Error HH502: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68a4158abfd08327b55615df0969b04c