### PR TITLE
feat: refresh kpp logo

### DIFF
--- a/assets/kpp-symbol.svg
+++ b/assets/kpp-symbol.svg
@@ -8,5 +8,11 @@
     </linearGradient>
   </defs>
   <circle cx="50" cy="50" r="48" fill="url(#brandGradient)" stroke="#ffffff" stroke-width="2"/>
-  <text x="50" y="50" font-size="25" font-family="Montserrat, sans-serif" text-anchor="middle" dominant-baseline="middle" fill="#222222">KPOP</text>
+  <g transform="translate(50 50)">
+    <path d="M0,-25 A25,25 0 0 1 21.65,12.5 L0,0 Z" fill="rgba(255,255,255,0.4)"/>
+    <path d="M0,-25 A25,25 0 0 1 21.65,12.5 L0,0 Z" fill="rgba(255,255,255,0.4)" transform="rotate(120)"/>
+    <path d="M0,-25 A25,25 0 0 1 21.65,12.5 L0,0 Z" fill="rgba(255,255,255,0.4)" transform="rotate(240)"/>
+  </g>
+  <text x="50" y="55" font-size="22" font-family="Montserrat, sans-serif" text-anchor="middle" fill="#ffffff" letter-spacing="2">KPP</text>
 </svg>
+


### PR DESCRIPTION
## Summary
- redesign KPP symbol with a gradient ring, internal swirl and crisp white text

## Testing
- `npm test` *(fails: Error HH502: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68a421caa53c832797859f50817e45ed