### PR TITLE
feat: craft coin-styled KPP logo

### DIFF
--- a/assets/kpp-symbol.svg
+++ b/assets/kpp-symbol.svg
@@ -1,12 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
   <defs>
-    <linearGradient id="brandGradient" x1="100%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#f6d365"/>
-      <stop offset="33%" stop-color="#fda085"/>
-      <stop offset="66%" stop-color="#a1c4fd"/>
-      <stop offset="100%" stop-color="#c2e9fb"/>
-    </linearGradient>
+    <radialGradient id="coinGradient" cx="30%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#fff4e0"/>
+      <stop offset="50%" stop-color="#f0ba45"/>
+      <stop offset="100%" stop-color="#b37e0a"/>
+    </radialGradient>
+    <radialGradient id="coreGradient" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#0e1e5b"/>
+      <stop offset="100%" stop-color="#1d4ed8"/>
+    </radialGradient>
   </defs>
-  <circle cx="50" cy="50" r="48" fill="url(#brandGradient)" stroke="#ffffff" stroke-width="2"/>
-  <text x="50" y="50" font-size="25" font-family="Montserrat, sans-serif" text-anchor="middle" dominant-baseline="middle" fill="#222222">KPOP</text>
+  <circle cx="50" cy="50" r="49" fill="url(#coinGradient)"/>
+  <g transform="translate(50 50)">
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(30)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(60)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(90)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(120)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(150)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(180)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(210)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(240)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(270)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(300)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(330)"/>
+  </g>
+  <circle cx="50" cy="50" r="38" fill="url(#coreGradient)"/>
+  <rect x="32" y="25" width="10" height="50" fill="#ffffff"/>
+  <polygon points="42,50 62,25 72,25 52,50 72,75 62,75" fill="#ffffff"/>
+  <path d="M42 30 h12 a10 10 0 0 1 0 20 h-12z" fill="#ffffff"/>
+  <path d="M42 50 h12 a10 10 0 0 1 0 20 h-12z" fill="#ffffff"/>
 </svg>


### PR DESCRIPTION
## Summary
- redesign KPP symbol as coin with metallic rim and deep-blue core
- add rim ticks and stylized KPP monogram in white

## Testing
- `npm test` *(fails: Error HH502: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68a421caa53c832797859f50817e45ed