### PR TITLE
feat: align KPOP logo with brand colors

### DIFF
--- a/assets/kpp-symbol.svg
+++ b/assets/kpp-symbol.svg
@@ -1,12 +1,30 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
   <defs>
-    <linearGradient id="brandGradient" x1="100%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#f6d365"/>
-      <stop offset="33%" stop-color="#fda085"/>
-      <stop offset="66%" stop-color="#a1c4fd"/>
-      <stop offset="100%" stop-color="#c2e9fb"/>
+    <radialGradient id="ringGradient" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ff77a9"/>
+      <stop offset="100%" stop-color="#7c4dff"/>
+    </radialGradient>
+    <linearGradient id="swooshGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff4081"/>
+      <stop offset="100%" stop-color="#7c4dff"/>
     </linearGradient>
   </defs>
-  <circle cx="50" cy="50" r="48" fill="url(#brandGradient)" stroke="#ffffff" stroke-width="2"/>
-  <text x="50" y="50" font-size="25" font-family="Montserrat, sans-serif" text-anchor="middle" dominant-baseline="middle" fill="#222222">KPOP</text>
+  <circle cx="50" cy="50" r="49" fill="url(#ringGradient)"/>
+  <g transform="translate(50 50)">
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(30)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(60)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(90)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(120)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(150)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(180)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(210)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(240)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(270)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(300)"/>
+    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(330)"/>
+  </g>
+  <circle cx="50" cy="50" r="38" fill="#222222"/>
+  <path d="M15 60 Q50 20 85 40 L85 60 Q50 80 15 60 Z" fill="url(#swooshGradient)" fill-opacity="0.6"/>
+  <text x="50" y="58" text-anchor="middle" font-family="sans-serif" font-size="28" font-weight="700" fill="#ffffff">KPOP</text>
 </svg>


### PR DESCRIPTION
## Summary
- recolor coin-style KPOP logo with pink-to-purple brand gradient
- overlay dynamic swoosh and bold white KPOP lettering for clarity

## Testing
- `npm test` *(fails: Error HH502: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68a421caa53c832797859f50817e45ed