### PR TITLE
Replace KPP symbol SVG

### DIFF
--- a/assets/kpp-symbol.svg
+++ b/assets/kpp-symbol.svg
@@ -1,30 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024">
   <defs>
-    <radialGradient id="ringGradient" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#ff77a9"/>
-      <stop offset="100%" stop-color="#7c4dff"/>
-    </radialGradient>
-    <linearGradient id="swooshGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#ff4081"/>
-      <stop offset="100%" stop-color="#7c4dff"/>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#77baf1"/>
+      <stop offset="100%" stop-color="#9776d7"/>
     </linearGradient>
   </defs>
-  <g transform="translate(50 50)">
-    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)"/>
-    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(30)"/>
-    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(60)"/>
-    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(90)"/>
-    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(120)"/>
-    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(150)"/>
-    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(180)"/>
-    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(210)"/>
-    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(240)"/>
-    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(270)"/>
-    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(300)"/>
-    <rect x="-2" y="-48" width="4" height="8" rx="1" fill="rgba(255,255,255,0.4)" transform="rotate(330)"/>
-  </g>
-  <circle cx="50" cy="50" r="38" fill="#222222"/>
-  <path d="M15 60 Q50 20 85 40 L85 60 Q50 80 15 60 Z" fill="url(#swooshGradient)" fill-opacity="0.6"/>
-  <text x="50" y="58" text-anchor="middle" font-family="sans-serif" font-size="28" font-weight="700" fill="#ffffff">KPOP</text>
+  <circle cx="511.80" cy="510.60" r="427.96" fill="url(#g)"/>
+  <path d="M 628.00 553.00 L 584.00 585.00 L 540.00 623.00 L 540.00 785.00 L 542.00 786.00 L 541.00 790.00 L 540.00 787.00 L 540.00 807.00 L 624.00 741.00 L 624.00 630.00 L 692.00 686.00 L 743.00 647.00 Z" fill="#ffffff"/>
+  <path d="M 502.00 449.00 L 479.00 458.00 L 464.00 472.00 L 453.00 495.00 L 452.00 518.00 L 460.00 541.00 L 473.00 556.00 L 494.00 567.00 L 520.00 569.00 L 540.00 562.00 L 559.00 546.00 L 570.00 522.00 L 571.00 502.00 L 564.00 480.00 L 548.00 461.00 L 537.00 454.00 L 528.00 453.00 L 525.00 450.00 Z" fill="#ffffff"/>
+  <path d="M 280.00 230.00 L 279.00 651.00 L 313.00 678.00 L 317.00 679.00 L 318.00 682.00 L 364.00 719.00 L 364.00 592.00 L 366.00 590.00 L 483.00 689.00 L 483.00 623.00 L 341.00 502.00 L 494.00 388.00 L 494.00 386.00 L 448.00 351.00 L 365.00 413.00 L 364.00 293.00 Z" fill="#ffffff"/>
+  <path d="M 744.00 229.00 L 531.00 387.00 L 594.00 436.00 L 653.00 390.00 L 658.00 389.00 L 658.00 524.00 L 744.00 460.00 Z" fill="#ffffff"/>
 </svg>
-


### PR DESCRIPTION
## Summary
- update KPP symbol asset with new gradient and white path design

## Testing
- `npm test` *(fails: Hardhat couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68a54d4d10208327bb953aa9929742b1