### PR TITLE
chore: update initial token supply in deployment script

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -6,7 +6,7 @@ async function main() {
   const [deployer] = await ethers.getSigners();
   console.log("Deploying with:", deployer.address);
 
-  const initialSupply = ethers.parseUnits("1000000", 18);
+  const initialSupply = ethers.parseUnits("202500000000", 18);
   const KPOPProtocol = await ethers.getContractFactory("KPOPProtocol");
   const token = await KPOPProtocol.deploy(initialSupply);
   await token.waitForDeployment();


### PR DESCRIPTION
## Summary
- update deploy script to mint 202,500,000,000 tokens on deployment

## Testing
- `npx hardhat run scripts/deploy.js --network hardhat` *(fails: Couldn't download compiler version list)*
- `npm test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68a56ad434d8832786261a66ac9bed63