### PR TITLE
refactor: load assets statically and enable caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,21 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-  <meta http-equiv="Pragma" content="no-cache">
-  <meta http-equiv="Expires" content="0">
   <title>KPOP Protocol</title>
   <link rel="icon" type="image/svg+xml" href="assets/kpp-symbol.svg">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0">
-  <script>
-    window.assetVersion = Date.now();
-    const style = document.createElement('link');
-    style.rel = 'stylesheet';
-    style.href = `style.css?v=${window.assetVersion}`;
-    document.head.appendChild(style);
-  </script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" integrity="sha384-7zwQ54nkbvi7fAXa5HHGGAFIAyWO9QgqOqSNisTSlRRv50hnsFfHWjgunnW8FoXN" crossorigin="anonymous">
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" integrity="sha384-d+vyQ0dYcymoP8ndq2hW7FGC50nqGdXUEgoOUGxbbkAJwZqL7h+jKN0GGgn9hFDS" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js" integrity="sha384-poC0r6usQOX2Ayt/VGA+t81H6V3iN9L+Irz9iO8o+s0X20tLpzc9DOOtnKxhaQSE" crossorigin="anonymous"></script>
 </head>
 <body data-page="index">
   <nav class="navbar">
@@ -468,11 +459,6 @@
 
   <button class="back-to-top" aria-label="맨 위로" data-i18n-aria-label="back_to_top"><i class="material-symbols-outlined">arrow_upward</i></button>
 
-  <script>
-    const script = document.createElement('script');
-    script.type = 'module';
-    script.src = `main.js?v=${window.assetVersion}`;
-    document.body.appendChild(script);
-  </script>
+  <script type="module" src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace script-injected stylesheet with static link
- Remove no-cache meta tags for standard caching
- Add SRI and CORS attributes to GSAP and Material Symbols resources
- Load `main.js` statically

## Testing
- `npm test` *(fails: couldn't download compiler version list, proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a66768c0c08327a2988fd43fb69d75