### PR TITLE
Load Google Fonts via link tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
   <meta http-equiv="Expires" content="0">
   <title>KPOP Protocol</title>
   <link rel="icon" type="image/svg+xml" href="assets/kpp-symbol.svg">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Poppins:wght@600&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&display=swap">
   <script>
     window.assetVersion = Date.now();
     const style = document.createElement('link');

--- a/style.css
+++ b/style.css
@@ -1,6 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Poppins:wght@600&family=Roboto:wght@400;500&display=swap');
-
-
 :root {
   --bg: #ffffff;
   --fg: #222222;


### PR DESCRIPTION
## Summary
- Load Montserrat, Poppins, and Roboto using `<link>` tags with preconnect hints and `display=swap`
- Remove Google Fonts `@import` from `style.css`
- Apply `display=swap` to Material Symbols

## Testing
- `npm test` *(fails: HH502 Couldn't download compiler version list)*
- `curl -I "https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Poppins:wght@600&family=Roboto:wght@400;500&display=swap"`
- `curl -I "https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&display=swap"`


------
https://chatgpt.com/codex/tasks/task_e_68a66771828c832781aaba4abb9994e0