### PR TITLE
Add local team images and update references

### DIFF
--- a/assets/team-daniel-kim.svg
+++ b/assets/team-daniel-kim.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#e0e0e0"/>
+  <text x="100" y="100" text-anchor="middle" dominant-baseline="central" font-size="72" fill="#333">DK</text>
+</svg>

--- a/assets/team-emily-lee.svg
+++ b/assets/team-emily-lee.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#d0d0f0"/>
+  <text x="100" y="100" text-anchor="middle" dominant-baseline="central" font-size="72" fill="#333">EL</text>
+</svg>

--- a/assets/team-michael-park.svg
+++ b/assets/team-michael-park.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#f0d0d0"/>
+  <text x="100" y="100" text-anchor="middle" dominant-baseline="central" font-size="72" fill="#333">MP</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -197,17 +197,17 @@
   <section class="team-section">
     <div class="team-grid">
         <div class="member">
-          <img src="https://source.unsplash.com/200x200/?korean,man" alt="Daniel Kim">
+          <img src="assets/team-daniel-kim.svg" alt="Portrait of Daniel Kim, CEO &amp; Co-Founder">
           <h3>Daniel Kim</h3>
           <p data-i18n="role_ceo">CEO &amp; Co-Founder</p>
         </div>
         <div class="member">
-          <img src="https://source.unsplash.com/200x200/?korean,woman" alt="Emily Lee">
+          <img src="assets/team-emily-lee.svg" alt="Portrait of Emily Lee, CTO">
           <h3>Emily Lee</h3>
           <p data-i18n="role_cto">CTO</p>
         </div>
         <div class="member">
-          <img src="https://source.unsplash.com/200x200/?korean,developer" alt="Michael Park">
+          <img src="assets/team-michael-park.svg" alt="Portrait of Michael Park, Lead Blockchain Engineer">
           <h3>Michael Park</h3>
           <p data-i18n="role_lead">Lead Blockchain Engineer</p>
         </div>


### PR DESCRIPTION
## Summary
- Add SVG placeholder images for team members in assets
- Reference local team images in index.html with descriptive alt text

## Testing
- `npm test` *(fails: couldn't download Hardhat compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68a66776a6748327aa2a6446e7db7e3e