### PR TITLE
feat: add burnable and mintable token

### DIFF
--- a/contracts/KPOPProtocol.sol
+++ b/contracts/KPOPProtocol.sol
@@ -2,9 +2,25 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract KPOPProtocol is ERC20 {
-    constructor(uint256 initialSupply) ERC20("KPOP Protocol", "KPP") {
+contract KPOPProtocol is ERC20, ERC20Burnable, Ownable {
+    uint256 public immutable maxSupply;
+
+    constructor(uint256 initialSupply, uint256 _maxSupply)
+        ERC20("KPOP Protocol", "KPP")
+        Ownable(msg.sender)
+    {
+        require(_maxSupply > 0, "max supply is zero");
+        require(initialSupply <= _maxSupply, "initial exceeds max supply");
+        maxSupply = _maxSupply;
         _mint(msg.sender, initialSupply);
     }
+
+    function mint(address to, uint256 amount) public onlyOwner {
+        require(totalSupply() + amount <= maxSupply, "cap exceeded");
+        _mint(to, amount);
+    }
 }
+

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -7,8 +7,9 @@ async function main() {
   console.log("Deploying with:", deployer.address);
 
   const initialSupply = ethers.parseUnits("1000000", 18);
+  const cap = ethers.parseUnits("2000000", 18);
   const KPOPProtocol = await ethers.getContractFactory("KPOPProtocol");
-  const token = await KPOPProtocol.deploy(initialSupply);
+  const token = await KPOPProtocol.deploy(initialSupply, cap);
   await token.waitForDeployment();
   const address = await token.getAddress();
   console.log("KPOPProtocol deployed to:", address);

--- a/test/KPOPProtocol.js
+++ b/test/KPOPProtocol.js
@@ -2,26 +2,56 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("KPOPProtocol", function () {
-  it("assigns initial supply to deployer", async function () {
-    const [owner] = await ethers.getSigners();
+  let owner, addr1, addr2, token;
+  const initialSupply = ethers.parseUnits("1000000", 18);
+  const cap = ethers.parseUnits("2000000", 18);
+
+  beforeEach(async function () {
+    [owner, addr1, addr2] = await ethers.getSigners();
     const KPOPProtocol = await ethers.getContractFactory("KPOPProtocol");
-    const initialSupply = ethers.parseUnits("1000000", 18);
-    const token = await KPOPProtocol.deploy(initialSupply);
+    token = await KPOPProtocol.deploy(initialSupply, cap);
     await token.waitForDeployment();
+  });
+
+  it("assigns initial supply to deployer", async function () {
     expect(await token.balanceOf(owner.address)).to.equal(initialSupply);
   });
 
   it("transfers tokens between accounts", async function () {
-    const [owner, addr1, addr2] = await ethers.getSigners();
-    const KPOPProtocol = await ethers.getContractFactory("KPOPProtocol");
-    const initialSupply = ethers.parseUnits("1000000", 18);
-    const token = await KPOPProtocol.deploy(initialSupply);
-    await token.waitForDeployment();
-
     await token.transfer(addr1.address, ethers.parseUnits("100", 18));
-    expect(await token.balanceOf(addr1.address)).to.equal(ethers.parseUnits("100", 18));
+    expect(await token.balanceOf(addr1.address)).to.equal(
+      ethers.parseUnits("100", 18)
+    );
 
-    await token.connect(addr1).transfer(addr2.address, ethers.parseUnits("50", 18));
-    expect(await token.balanceOf(addr2.address)).to.equal(ethers.parseUnits("50", 18));
+    await token
+      .connect(addr1)
+      .transfer(addr2.address, ethers.parseUnits("50", 18));
+    expect(await token.balanceOf(addr2.address)).to.equal(
+      ethers.parseUnits("50", 18)
+    );
+  });
+
+  it("only owner can mint up to cap", async function () {
+    const mintAmount = ethers.parseUnits("1000", 18);
+    await token.mint(addr1.address, mintAmount);
+    expect(await token.balanceOf(addr1.address)).to.equal(mintAmount);
+
+    await expect(
+      token.connect(addr1).mint(addr1.address, mintAmount)
+    )
+      .to.be.revertedWithCustomError(token, "OwnableUnauthorizedAccount")
+      .withArgs(addr1.address);
+
+    const remaining = cap - (initialSupply + mintAmount);
+    await token.mint(owner.address, remaining);
+    await expect(token.mint(owner.address, 1n)).to.be.revertedWith(
+      "cap exceeded"
+    );
+  });
+
+  it("burn reduces total supply", async function () {
+    const burnAmount = ethers.parseUnits("500", 18);
+    await token.burn(burnAmount);
+    expect(await token.totalSupply()).to.equal(initialSupply - burnAmount);
   });
 });


### PR DESCRIPTION
## Summary
- add owner-only mintable and burnable token with max supply
- update deployment script for new constructor arguments
- expand tests for minting, burning, and supply cap

## Testing
- `npm test` (fails: Couldn't download compiler version list)

------
https://chatgpt.com/codex/tasks/task_e_68a6677bb2188327843c04cdbb0d8075