### PR TITLE
Use accessible status element for newsletter signups

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,7 @@
       <input type="email" required data-i18n-placeholder="newsletter_placeholder" placeholder="이메일 주소">
       <button type="submit" class="btn" data-i18n="newsletter_button">구독하기</button>
     </form>
+    <p class="newsletter-success" role="status" hidden></p>
   </section>
 
   <section id="faq">

--- a/main.js
+++ b/main.js
@@ -201,12 +201,21 @@ if (hero && fancy) {
 }
 
 const newsletterForm = document.querySelector('.newsletter-form');
-if (newsletterForm) {
+const newsletterMessage = document.querySelector('.newsletter-success');
+let newsletterTimeout;
+
+if (newsletterForm && newsletterMessage) {
   newsletterForm.addEventListener('submit', async e => {
     e.preventDefault();
     const lang = localStorage.getItem('lang') || 'ko';
     await loadLanguage(lang);
-    alert(translations[lang].newsletter_success);
+    newsletterMessage.textContent = translations[lang].newsletter_success;
+    newsletterMessage.hidden = false;
+    clearTimeout(newsletterTimeout);
+    newsletterTimeout = setTimeout(() => {
+      newsletterMessage.hidden = true;
+      newsletterMessage.textContent = '';
+    }, 5000);
     newsletterForm.reset();
   });
 }

--- a/style.css
+++ b/style.css
@@ -291,6 +291,11 @@ ul, ol {
   margin-top: 1.5rem;
 }
 
+.newsletter-success {
+  margin-top: 1rem;
+  color: #2e7d32;
+}
+
 .newsletter-form input {
   padding: 0.7rem 1rem;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
- Replace `alert()` with inline status message for newsletter signups
- Show and hide success message using translations
- Style success message and mark with `role="status"`

## Testing
- `npm test` *(fails: Couldn't download compiler version list, HardhatError HH502)*

------
https://chatgpt.com/codex/tasks/task_e_68a6678149208327926d2fec1fb1c030