### PR TITLE
Add locale check script and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run check-locales
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Pull requests are welcome. For major changes, please open an issue first to disc
 Before committing changes to translation files in `locales/`, run the locale consistency check:
 
 ```bash
-node scripts/check-locales.js
+npm run check-locales
 ```
 
-This script ensures every locale file has the same keys as `locales/en.json` and reports any missing or extra entries.
+This script ensures every locale file has the same keys as `locales/en.json` and reports any missing or extra entries. The check is also executed in the CI pipeline.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "compile": "npx hardhat compile",
     "test": "npx hardhat test",
-    "deploy": "npx hardhat run scripts/deploy.js --network hardhat"
+    "deploy": "npx hardhat run scripts/deploy.js --network hardhat",
+    "check-locales": "node scripts/check-locales.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `check-locales` npm script to verify translation consistency
- run locale check in GitHub Actions workflow
- document locale check command in contributing guidelines

## Testing
- `npm run check-locales`
- `npm test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68a66bd613608327b9d81394816e723c