### PR TITLE
fix: add missing comma in package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npx hardhat test",
     "deploy": "npx hardhat run scripts/deploy.js --network hardhat",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
     "check-locales": "node scripts/check-locales.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- fix `package.json` JSON syntax by adding missing comma in `scripts`

## Testing
- `npm ci`
- `npm test` *(fails: Couldn't download compiler version list due to network/proxy response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a670334afc8327a4bdb35acb8f93da