### PR TITLE
Enable offline compilation for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 .env
+artifacts/
+cache/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "main.js",
   "scripts": {
     "compile": "npx hardhat compile",
-    "test": "npx hardhat test",
+    "pretest": "node scripts/offline-compile.js",
+    "test": "npx hardhat test --no-compile",
     "deploy": "npx hardhat run scripts/deploy.js --network hardhat",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint .",
     "format": "prettier --write .",

--- a/scripts/offline-compile.js
+++ b/scripts/offline-compile.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+const solc = require('solc');
+
+const sourcePath = path.join(__dirname, '..', 'contracts', 'KPOPProtocol.sol');
+const source = fs.readFileSync(sourcePath, 'utf8');
+
+const input = {
+  language: 'Solidity',
+  sources: {
+    'contracts/KPOPProtocol.sol': { content: source },
+  },
+  settings: {
+    optimizer: { enabled: false, runs: 200 },
+    outputSelection: {
+      '*': {
+        '*': ['abi', 'evm.bytecode', 'evm.deployedBytecode'],
+      },
+    },
+  },
+};
+
+function findImports(importPath) {
+  const basePath = importPath.startsWith('@')
+    ? path.join(__dirname, '..', 'node_modules', importPath)
+    : path.join(__dirname, '..', importPath);
+  if (fs.existsSync(basePath)) {
+    return { contents: fs.readFileSync(basePath, 'utf8') };
+  }
+  return { error: 'File not found' };
+}
+
+const output = JSON.parse(
+  solc.compile(JSON.stringify(input), { import: findImports })
+);
+if (output.errors) {
+  for (const err of output.errors) {
+    console.error(err.formattedMessage);
+  }
+  if (output.errors.some((e) => e.severity === 'error')) {
+    process.exit(1);
+  }
+}
+
+const contract = output.contracts['contracts/KPOPProtocol.sol']['KPOPProtocol'];
+const artifact = {
+  contractName: 'KPOPProtocol',
+  sourceName: 'contracts/KPOPProtocol.sol',
+  abi: contract.abi,
+  bytecode: contract.evm.bytecode.object
+    ? '0x' + contract.evm.bytecode.object
+    : '0x',
+  deployedBytecode: contract.evm.deployedBytecode.object
+    ? '0x' + contract.evm.deployedBytecode.object
+    : '0x',
+  linkReferences: contract.evm.bytecode.linkReferences || {},
+  deployedLinkReferences: contract.evm.deployedBytecode.linkReferences || {},
+};
+
+const artifactsDir = path.join(
+  __dirname,
+  '..',
+  'artifacts',
+  'contracts',
+  'KPOPProtocol.sol'
+);
+fs.mkdirSync(artifactsDir, { recursive: true });
+fs.writeFileSync(
+  path.join(artifactsDir, 'KPOPProtocol.json'),
+  JSON.stringify(artifact, null, 2)
+);


### PR DESCRIPTION
## Summary
- run an offline solc compiler before tests
- skip Hardhat's compiler download during tests
- ignore build artifacts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6714fe2348327b439248d07271d5d