### PR TITLE
Add focus outlines for keyboard navigation

### DIFF
--- a/style.css
+++ b/style.css
@@ -108,6 +108,11 @@ html {
   margin-left: 1rem;
 }
 
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .menu-toggle {
   display: none;
   background: none;
@@ -115,6 +120,11 @@ html {
   color: var(--fg);
   font-size: 1.5rem;
   margin-left: auto;
+}
+
+.menu-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .hero {
@@ -400,6 +410,11 @@ ul, ol {
   z-index: 20;
 }
 
+.back-to-top:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .back-to-top.visible {
   opacity: 1;
   pointer-events: auto;
@@ -433,6 +448,11 @@ body.dark-mode .footer {
   text-decoration: none;
   cursor: pointer;
   transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .btn:hover {


### PR DESCRIPTION
## Summary
- Add `:focus-visible` styles to theme toggle and menu toggle buttons
- Highlight back-to-top and generic buttons when focused via keyboard for better accessibility

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a66ec8c2fc8327be01dc4c5261b5da