### PR TITLE
feat: respect system theme with CSS media query

### DIFF
--- a/main.js
+++ b/main.js
@@ -196,23 +196,38 @@ if (menuToggle) {
 }
 
 const themeToggle = document.querySelector('.theme-toggle');
+
+function isDark() {
+  return (
+    document.body.classList.contains('dark-mode') ||
+    (!document.body.classList.contains('light-mode') &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches)
+  );
+}
+
 function updateThemeIcon() {
   if (!themeToggle) return;
-  themeToggle.innerHTML = document.body.classList.contains('dark-mode')
+  themeToggle.innerHTML = isDark()
     ? '<i class="material-symbols-outlined">light_mode</i>'
     : '<i class="material-symbols-outlined">dark_mode</i>';
 }
+
 function setTheme(theme) {
   document.body.classList.toggle('dark-mode', theme === 'dark');
-  localStorage.setItem('theme', theme);
+  document.body.classList.toggle('light-mode', theme === 'light');
+  if (theme) {
+    localStorage.setItem('theme', theme);
+  }
   updateThemeIcon();
 }
+
 if (themeToggle) {
   const saved = localStorage.getItem('theme');
-  const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  setTheme(saved || prefers);
+  if (saved) setTheme(saved);
+  else updateThemeIcon();
+
   themeToggle.addEventListener('click', () => {
-    const next = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+    const next = isDark() ? 'light' : 'dark';
     setTheme(next);
   });
 }

--- a/style.css
+++ b/style.css
@@ -1,13 +1,38 @@
+/* light theme variables */
 :root {
   --bg: #ffffff;
   --fg: #222222;
   --accent: #ff4081;
 }
 
+/* dark theme variables via media query */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #121212;
+    --fg: #f5f5f5;
+  }
+}
+
+body {
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color-scheme: dark;
+  }
+}
+
 body.dark-mode {
   --bg: #121212;
   --fg: #f5f5f5;
   color-scheme: dark;
+}
+
+body.light-mode {
+  --bg: #ffffff;
+  --fg: #222222;
+  color-scheme: light;
 }
 
 .material-symbols-outlined {
@@ -23,7 +48,6 @@ html, body {
   font-family: 'Roboto', sans-serif;
   font-size: 15px;
   line-height: 1.6;
-  color-scheme: light;
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
## Summary
- detect system dark mode in CSS using `prefers-color-scheme`
- set body color scheme via media queries to avoid flash
- let JavaScript toggle dark/light classes for manual override

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6742246508327868ea236141c2b9a