### PR TITLE
feat: add notice element for status messages

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,24 @@ gsap.registerPlugin(ScrollTrigger);
 // Respect users who prefer reduced motion by checking their system setting
 const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
+// Reusable notice element for status messages
+const notice = document.createElement('div');
+notice.className = 'notice';
+notice.setAttribute('role', 'status');
+notice.setAttribute('aria-live', 'polite');
+notice.hidden = true;
+document.body.appendChild(notice);
+let noticeTimeout;
+function showNotice(message, delay = 4000) {
+  notice.textContent = message;
+  notice.hidden = false;
+  clearTimeout(noticeTimeout);
+  noticeTimeout = setTimeout(() => {
+    notice.hidden = true;
+    notice.textContent = '';
+  }, delay);
+}
+
 class KPPFancyTitle extends HTMLElement {
   static get observedAttributes() { return ['text', 'size']; }
   constructor() {
@@ -134,11 +152,11 @@ async function loadLanguage(lang) {
 async function setLanguage(lang) {
   const loadedLang = await loadLanguage(lang);
   if (!loadedLang) {
-    alert('Localization failed to load.');
+    showNotice('Localization failed to load.');
     return;
   }
   if (loadedLang !== lang) {
-    alert('Selected language unavailable. Using default language.');
+    showNotice('Selected language unavailable. Using default language.');
   }
   lang = loadedLang;
   localStorage.setItem('lang', lang);

--- a/style.css
+++ b/style.css
@@ -530,3 +530,16 @@ body.dark-mode .footer {
     font-size: 1.05rem;
   }
 }
+
+.notice {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--fg);
+  color: var(--bg);
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- add reusable notice element and helper for status messaging
- replace language alerts with auto-dismiss notice
- style notice component for visibility and theme contrast

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6795fe9f88327a905315eee492358