### PR TITLE
Use ERC20Capped for supply cap enforcement

### DIFF
--- a/contracts/KPOPProtocol.sol
+++ b/contracts/KPOPProtocol.sol
@@ -1,26 +1,28 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Capped.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract KPOPProtocol is ERC20, ERC20Burnable, Ownable {
-    uint256 public immutable maxSupply;
-
-    constructor(uint256 initialSupply, uint256 _maxSupply)
+contract KPOPProtocol is ERC20Capped, ERC20Burnable, Ownable {
+    constructor(uint256 initialSupply, uint256 cap)
         ERC20("KPOP Protocol", "KPP")
+        ERC20Capped(cap)
         Ownable(msg.sender)
     {
-        require(_maxSupply > 0, "max supply is zero");
-        require(initialSupply <= _maxSupply, "initial exceeds max supply");
-        maxSupply = _maxSupply;
         _mint(msg.sender, initialSupply);
     }
 
     function mint(address to, uint256 amount) public onlyOwner {
-        require(totalSupply() + amount <= maxSupply, "cap exceeded");
         _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value)
+        internal
+        override(ERC20, ERC20Capped)
+    {
+        super._update(from, to, value);
     }
 }
 

--- a/test/KPOPProtocol.js
+++ b/test/KPOPProtocol.js
@@ -44,9 +44,9 @@ describe("KPOPProtocol", function () {
 
     const remaining = cap - (initialSupply + mintAmount);
     await token.mint(owner.address, remaining);
-    await expect(token.mint(owner.address, 1n)).to.be.revertedWith(
-      "cap exceeded"
-    );
+    await expect(token.mint(owner.address, 1n))
+      .to.be.revertedWithCustomError(token, "ERC20ExceededCap")
+      .withArgs(cap + 1n, cap);
   });
 
   it("burn reduces total supply", async function () {


### PR DESCRIPTION
## Summary
- Extend `ERC20Capped` and drop custom max supply state
- Pass the cap through the constructor and rely on built-in limit checks
- Update tests to expect `ERC20ExceededCap` when minting beyond cap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a679694cac8327b1190c040f6427b9