### PR TITLE
Fix Material Icons link integrity causing blocked font

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/kpp-symbol.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" integrity="sha384-7zwQ54nkbvi7fAXa5HHGGAFIAyWO9QgqOqSNisTSlRRv50hnsFfHWjgunnW8FoXN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" crossorigin="anonymous">
   <link rel="stylesheet" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" integrity="sha384-d+vyQ0dYcymoP8ndq2hW7FGC50nqGdXUEgoOUGxbbkAJwZqL7h+jKN0GGgn9hFDS" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js" integrity="sha384-poC0r6usQOX2Ayt/VGA+t81H6V3iN9L+Irz9iO8o+s0X20tLpzc9DOOtnKxhaQSE" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- remove invalid integrity attribute from Material Symbols Outlined Google Font link
- allow Material icons to load correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a67ae2a8a08327b453ffd97ce7b1c7