### PR TITLE
feat: add hero backdrop tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ The site is fully static and can be served by any web server.
 - Responsive layout driven by modern CSS.
 - Feature cards highlight fan participation, artist support, and global community building.
 
+## Design Tokens
+The site relies on CSS custom properties for theming. Two key tokens exposed for the hero section are:
+
+- `--hero-gradient`: controls the animated gradient backdrop of the hero. Defaults to a light pastel gradient and shifts to a deeper palette in dark mode.
+- `--hero-blur`: sets the blur radius applied to the hero backdrop, enabling easy refinement of the effect.
+
 ## Local Development
 1. Clone the repository and change into the project directory:
    ```bash

--- a/style.css
+++ b/style.css
@@ -4,6 +4,8 @@
   --fg: #222222;
   --accent: #ff4081;
   --surface: rgba(0,0,0,0.05);
+  --hero-gradient: linear-gradient(-45deg,#fff1f2,#fffbeb,#e0f2fe,#f3e8ff);
+  --hero-blur: 60px;
 }
 
 /* dark theme variables via media query */
@@ -12,6 +14,8 @@
     --bg: #121212;
     --fg: #f5f5f5;
     --surface: rgba(255,255,255,0.1);
+    --hero-gradient: linear-gradient(-45deg,#4e54c8,#8f94fb,#232526,#414345);
+    --hero-blur: 80px;
   }
 }
 
@@ -29,6 +33,8 @@ body.dark-mode {
   --bg: #121212;
   --fg: #f5f5f5;
   --surface: rgba(255,255,255,0.1);
+  --hero-gradient: linear-gradient(-45deg,#4e54c8,#8f94fb,#232526,#414345);
+  --hero-blur: 80px;
   color-scheme: dark;
 }
 
@@ -36,6 +42,8 @@ body.light-mode {
   --bg: #ffffff;
   --fg: #222222;
   --surface: rgba(0,0,0,0.05);
+  --hero-gradient: linear-gradient(-45deg,#fff1f2,#fffbeb,#e0f2fe,#f3e8ff);
+  --hero-blur: 60px;
   color-scheme: light;
 }
 
@@ -175,11 +183,11 @@ html {
   left: 0;
   width: 100%;
   height: 100%;
-  background: linear-gradient(-45deg,#f6d365,#fda085,#a1c4fd,#c2e9fb);
+  background: var(--hero-gradient);
   background-size: 400% 400%;
   animation: heroGradient 15s ease infinite;
   z-index: -1;
-  filter: blur(80px);
+  filter: blur(var(--hero-blur));
 }
 
 @keyframes heroGradient {


### PR DESCRIPTION
## Summary
- add `--hero-gradient` and `--hero-blur` CSS variables with light and dark values
- apply new variables to `.hero::before`
- document hero design tokens in the README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a68340477083278bad6198f438ef9a