### PR TITLE
Fix content offset by adding nav height variable

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@
   --surface: rgba(0,0,0,0.05);
   --hero-gradient: linear-gradient(-45deg,#fff1f2,#fffbeb,#e0f2fe,#f3e8ff);
   --hero-blur: 60px;
+  --nav-height: 60px;
   --space-xs: 0.5rem;
   --space-sm: 1rem;
   --space-md: 1.5rem;
@@ -73,6 +74,11 @@ html, body {
 
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: var(--nav-height);
+}
+
+body {
+  padding-top: var(--nav-height);
 }
 
 .navbar {


### PR DESCRIPTION
## Summary
- define `--nav-height` variable for consistent navbar spacing
- offset initial content and anchor scroll with navbar height

## Testing
- `npm test`
- `npm run lint`
- `npm run check-locales`


------
https://chatgpt.com/codex/tasks/task_e_68a6873cd36c8327918d6dcfb4672066