### PR TITLE
Reduce card spacing on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -560,7 +560,7 @@ body.dark-mode .footer {
   }
 
   .card-grid {
-    gap: calc(var(--space-lg) + var(--space-xs));
+    gap: var(--space-md);
   }
 
   .btn {


### PR DESCRIPTION
## Summary
- reduce `.card-grid` gap on small screens for tighter card layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6893c026c832798989a18210cc07c