### PR TITLE
Use nav height variable for hero min-height

### DIFF
--- a/style.css
+++ b/style.css
@@ -179,7 +179,7 @@ body {
   justify-content: center;
   align-items: center;
   text-align: center;
-  height: 100vh;
+  min-height: calc(100vh - var(--nav-height));
   padding: 0 1rem;
   position: relative;
   overflow: hidden;
@@ -551,7 +551,7 @@ body.dark-mode .footer {
     }
 
   .hero {
-    height: auto;
+    min-height: calc(100vh - var(--nav-height));
     padding: calc(var(--space-lg) * 3) var(--space-md) calc(var(--space-lg) * 2);
   }
 


### PR DESCRIPTION
## Summary
- calculate hero min-height using `--nav-height` so content fits below navigation bar
- apply the same min-height logic in small-screen media query

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6968abf448327acb765597f6c8a92