### PR TITLE
Use default language constant for initial and newsletter fallback

### DIFF
--- a/main.js
+++ b/main.js
@@ -205,7 +205,7 @@ async function setLanguage(lang) {
   if (select) select.value = lang;
 }
 
-const currentLang = localStorage.getItem('lang') || 'ko';
+const currentLang = localStorage.getItem('lang') || DEFAULT_LANG;
 setLanguage(currentLang);
 
 async function loadWhitepaper(lang) {
@@ -309,7 +309,7 @@ let newsletterTimeout;
 if (newsletterForm && newsletterMessage) {
   newsletterForm.addEventListener('submit', async e => {
     e.preventDefault();
-    const lang = localStorage.getItem('lang') || 'ko';
+    const lang = localStorage.getItem('lang') || DEFAULT_LANG;
     await loadLanguage(lang);
     newsletterMessage.textContent = translations[lang].newsletter_success;
     newsletterMessage.hidden = false;


### PR DESCRIPTION
## Summary
- Use shared `DEFAULT_LANG` constant instead of hard-coded Korean fallback for initial page load
- Apply the same default language when submitting the newsletter form

## Testing
- `npm run lint`
- `npm test`
- `npm run check-locales`


------
https://chatgpt.com/codex/tasks/task_e_68a698c8b70883278a40bfa8b5b6696d