### PR TITLE
Improve team section image loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,17 +201,17 @@
   <section class="team-section">
     <div class="team-grid">
         <div class="member">
-          <img src="assets/team-daniel-kim.svg" alt="Portrait of Daniel Kim, CEO &amp; Co-Founder">
+          <img src="assets/team-daniel-kim.svg" alt="Portrait of Daniel Kim, CEO &amp; Co-Founder" loading="lazy">
           <h3>Daniel Kim</h3>
           <p data-i18n="role_ceo">CEO &amp; Co-Founder</p>
         </div>
         <div class="member">
-          <img src="assets/team-emily-lee.svg" alt="Portrait of Emily Lee, CTO">
+          <img src="assets/team-emily-lee.svg" alt="Portrait of Emily Lee, CTO" loading="lazy">
           <h3>Emily Lee</h3>
           <p data-i18n="role_cto">CTO</p>
         </div>
         <div class="member">
-          <img src="assets/team-michael-park.svg" alt="Portrait of Michael Park, Lead Blockchain Engineer">
+          <img src="assets/team-michael-park.svg" alt="Portrait of Michael Park, Lead Blockchain Engineer" loading="lazy">
           <h3>Michael Park</h3>
           <p data-i18n="role_lead">Lead Blockchain Engineer</p>
         </div>


### PR DESCRIPTION
## Summary
- lazily load team member images to speed up initial page rendering

## Testing
- `npm run lint`
- `npm run check-locales`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a69a6e3e088327b339401d6791d6b7