### PR TITLE
Avoid double-wrapping h2 titles

### DIFF
--- a/main.js
+++ b/main.js
@@ -95,6 +95,7 @@ function applyFancyTitles() {
     h1.replaceWith(fancy);
   });
   document.querySelectorAll('h2').forEach(h2 => {
+    if (h2.closest('kpp-fancy-title')) return;
     const fancy = document.createElement('kpp-fancy-title');
     fancy.setAttribute('size', 'medium');
     fancy.setAttribute('text', h2.textContent.trim());


### PR DESCRIPTION
## Summary
- prevent `applyFancyTitles` from wrapping `h2` elements already inside `kpp-fancy-title`

## Testing
- `npm run lint`
- `npm test`
- `npm run check-locales`


------
https://chatgpt.com/codex/tasks/task_e_68a69b4813508327af4d26fa0f0b283a