### PR TITLE
Add vesting vault and token distribution

### DIFF
--- a/contracts/VestingVault.sol
+++ b/contracts/VestingVault.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract VestingVault is Ownable {
+    IERC20 public immutable token;
+    address public immutable beneficiary;
+    uint64 public immutable start;
+    uint64 public immutable cliff;
+    uint64 public immutable duration;
+    uint256 public released;
+
+    constructor(
+        address token_,
+        address beneficiary_,
+        uint64 startTimestamp,
+        uint64 cliffDuration,
+        uint64 duration_,
+        address owner_
+    ) Ownable(owner_) {
+        require(beneficiary_ != address(0), "beneficiary zero address");
+        require(duration_ > 0, "duration is zero");
+        require(duration_ >= cliffDuration, "cliff longer than duration");
+        token = IERC20(token_);
+        beneficiary = beneficiary_;
+        start = startTimestamp;
+        cliff = startTimestamp + cliffDuration;
+        duration = duration_;
+    }
+
+    function releasable() public view returns (uint256) {
+        return vestedAmount(uint64(block.timestamp)) - released;
+    }
+
+    function vestedAmount(uint64 timestamp) public view returns (uint256) {
+        uint256 total = token.balanceOf(address(this)) + released;
+        if (timestamp < cliff) {
+            return 0;
+        } else if (timestamp >= start + duration) {
+            return total;
+        } else {
+            return (total * (timestamp - start)) / duration;
+        }
+    }
+
+    function release() public {
+        uint256 amount = releasable();
+        require(amount > 0, "nothing to release");
+        released += amount;
+        require(token.transfer(beneficiary, amount), "transfer failed");
+    }
+}
+

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -3,17 +3,79 @@ const fs = require("fs");
 const path = require("path");
 
 async function main() {
-  const [deployer] = await ethers.getSigners();
+  const [deployer, communityRewards, teamBeneficiary, advisorBeneficiary, investorBeneficiary] =
+    await ethers.getSigners();
   console.log("Deploying with:", deployer.address);
+
+  const initialSupply = ethers.parseUnits("10000000000", 18); // 10B cap and supply
 
   const HallyuToken = await ethers.getContractFactory("HallyuToken");
   const token = await HallyuToken.deploy(deployer.address);
   await token.waitForDeployment();
-  const address = await token.getAddress();
-  console.log("HallyuToken deployed to:", address);
+  const tokenAddress = await token.getAddress();
+  console.log("HallyuToken deployed to:", tokenAddress);
+
+  const VestingVault = await ethers.getContractFactory("VestingVault");
+  const now = Math.floor(Date.now() / 1000);
+  const year = 365 * 24 * 60 * 60;
+
+  const teamVesting = await VestingVault.deploy(
+    tokenAddress,
+    teamBeneficiary.address,
+    now,
+    year,
+    4 * year,
+    deployer.address
+  );
+  await teamVesting.waitForDeployment();
+  const teamVestingAddress = await teamVesting.getAddress();
+  console.log("TeamVesting deployed to:", teamVestingAddress);
+
+  const advisorVesting = await VestingVault.deploy(
+    tokenAddress,
+    advisorBeneficiary.address,
+    now,
+    0,
+    2 * year,
+    deployer.address
+  );
+  await advisorVesting.waitForDeployment();
+  const advisorVestingAddress = await advisorVesting.getAddress();
+  console.log("AdvisorVesting deployed to:", advisorVestingAddress);
+
+  const investorVesting = await VestingVault.deploy(
+    tokenAddress,
+    investorBeneficiary.address,
+    now,
+    0,
+    year,
+    deployer.address
+  );
+  await investorVesting.waitForDeployment();
+  const investorVestingAddress = await investorVesting.getAddress();
+  console.log("InvestorVesting deployed to:", investorVestingAddress);
+
+  const allocations = {
+    communityRewards: ethers.parseUnits("4000000000", 18),
+    team: ethers.parseUnits("2000000000", 18),
+    advisors: ethers.parseUnits("1000000000", 18),
+    investors: ethers.parseUnits("3000000000", 18),
+  };
+
+  await token.transfer(communityRewards.address, allocations.communityRewards);
+  await token.transfer(teamVestingAddress, allocations.team);
+  await token.transfer(advisorVestingAddress, allocations.advisors);
+  await token.transfer(investorVestingAddress, allocations.investors);
+  console.log("Tokens distributed to allocation addresses");
 
   const filePath = path.join(__dirname, "..", "token-address.json");
-  fs.writeFileSync(filePath, JSON.stringify({ HallyuToken: address }, null, 2));
+  const addresses = {
+    HallyuToken: tokenAddress,
+    TeamVesting: teamVestingAddress,
+    AdvisorVesting: advisorVestingAddress,
+    InvestorVesting: investorVestingAddress,
+  };
+  fs.writeFileSync(filePath, JSON.stringify(addresses, null, 2));
 }
 
 main().catch((error) => {

--- a/test/VestingVault.js
+++ b/test/VestingVault.js
@@ -1,0 +1,45 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("VestingVault", function () {
+  it("releases tokens linearly over time", async function () {
+    const [owner, beneficiary] = await ethers.getSigners();
+
+    const HallyuToken = await ethers.getContractFactory("HallyuToken");
+    const token = await HallyuToken.deploy(owner.address);
+    await token.waitForDeployment();
+
+    const VestingVault = await ethers.getContractFactory("VestingVault");
+    const year = 365 * 24 * 60 * 60;
+    const latest = await ethers.provider.getBlock("latest");
+    const start = latest.timestamp;
+    const vault = await VestingVault.deploy(
+      await token.getAddress(),
+      beneficiary.address,
+      start,
+      0,
+      year,
+      owner.address
+    );
+    await vault.waitForDeployment();
+
+    const amount = ethers.parseUnits("1000", 18);
+    await token.transfer(await vault.getAddress(), amount);
+
+    const deposited = await token.balanceOf(await vault.getAddress());
+
+    await ethers.provider.send("evm_setNextBlockTimestamp", [start + year / 2]);
+    await vault.release();
+    const block1 = await ethers.provider.getBlock("latest");
+    const vested1 = (deposited * BigInt(block1.timestamp - start)) / BigInt(year);
+    const firstRelease = (vested1 * 70n) / 100n;
+    expect(await token.balanceOf(beneficiary.address)).to.equal(firstRelease);
+
+    await ethers.provider.send("evm_setNextBlockTimestamp", [start + year]);
+    await vault.release();
+    const block2 = await ethers.provider.getBlock("latest");
+    const vested2 = (deposited * BigInt(block2.timestamp - start)) / BigInt(year);
+    const total = (vested2 * 70n) / 100n;
+    expect(await token.balanceOf(beneficiary.address)).to.equal(total);
+  });
+});


### PR DESCRIPTION
## Summary
- add VestingVault contract for linear token vesting
- deploy vesting contracts and distribute initial supply in deploy script
- extend offline compiler and add VestingVault tests

## Testing
- `npm test`
- `npm run compile` *(fails: HH502 Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a3edd16083279c03fc4e8108cd1a