### PR TITLE
Fix mobile menu remaining open after navigation

### DIFF
--- a/main.js
+++ b/main.js
@@ -287,6 +287,13 @@ if (menuToggle && navLinks) {
       if (firstLink) firstLink.focus();
     }
   });
+  navLinks.addEventListener('click', (e) => {
+    if (e.target.closest('a')) {
+      const navbar = document.querySelector('.navbar');
+      navbar.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+    }
+  });
 }
 
 const themeToggle = document.querySelector('.theme-toggle');


### PR DESCRIPTION
## Summary
- Close the mobile navigation menu when a link is tapped

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c9d6060c8327af26190ba5accfe9