### PR TITLE
feat: enhance navbar keyboard accessibility

### DIFF
--- a/main.js
+++ b/main.js
@@ -289,11 +289,13 @@ if (select) {
 
 const menuToggle = document.querySelector('.menu-toggle');
 const navLinks = document.getElementById('primary-navigation');
+if (navLinks) navLinks.setAttribute('aria-hidden', 'true');
 if (menuToggle && navLinks) {
   menuToggle.addEventListener('click', () => {
     const navbar = document.querySelector('.navbar');
     const open = navbar.classList.toggle('open');
     menuToggle.setAttribute('aria-expanded', open);
+    navLinks.setAttribute('aria-hidden', open ? 'false' : 'true');
     if (open) {
       const firstLink = navLinks.querySelector('a');
       if (firstLink) firstLink.focus();
@@ -304,9 +306,34 @@ if (menuToggle && navLinks) {
       const navbar = document.querySelector('.navbar');
       navbar.classList.remove('open');
       menuToggle.setAttribute('aria-expanded', 'false');
+      navLinks.setAttribute('aria-hidden', 'true');
+    }
+  });
+  navLinks.addEventListener('keydown', (e) => {
+    if (e.key !== 'Tab') return;
+    const navbar = document.querySelector('.navbar');
+    if (!navbar.classList.contains('open')) return;
+    const links = navLinks.querySelectorAll('a');
+    const firstLink = links[0];
+    const lastLink = links[links.length - 1];
+    if (!e.shiftKey && document.activeElement === lastLink) {
+      e.preventDefault();
+      firstLink.focus();
+    } else if (e.shiftKey && document.activeElement === firstLink) {
+      e.preventDefault();
+      lastLink.focus();
     }
   });
 }
+
+document.addEventListener('keydown', (e) => {
+  if (e.key !== 'Escape') return;
+  const navbar = document.querySelector('.navbar');
+  if (!navbar.classList.contains('open')) return;
+  navbar.classList.remove('open');
+  if (menuToggle) menuToggle.setAttribute('aria-expanded', 'false');
+  if (navLinks) navLinks.setAttribute('aria-hidden', 'true');
+});
 
 const themeToggle = document.querySelector('.theme-toggle');
 


### PR DESCRIPTION
## Summary
- close mobile navbar with Escape key and update `aria-expanded`/`aria-hidden`
- keep focus trapped inside open menu so first and last links cycle
- manage menu visibility state via `aria-hidden` for better accessibility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6d40f49948327beab78c4fda06ff9