### PR TITLE
feat: add google fonts for site

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,10 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"
       crossorigin="anonymous"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto&family=Montserrat:wght@700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="style.css" />
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"

--- a/style.css
+++ b/style.css
@@ -206,7 +206,8 @@ body {
 }
 
 .hero h1 {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
   font-size: clamp(2.5rem, 8vw, 4rem);
   margin: 0;
   background: linear-gradient(45deg,#ff4081,#7c4dff);
@@ -226,7 +227,8 @@ section {
 }
 
 section h2 {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
   text-align: center;
   margin-bottom: var(--space-lg);
   font-size: 1.8rem;
@@ -285,7 +287,8 @@ ul, ol {
 }
 
 .card h3 {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
   margin: 0 0 var(--space-xs);
   font-size: 1.2rem;
 }


### PR DESCRIPTION
## Summary
- load Roboto and Montserrat fonts from Google Fonts
- switch heading styles to use Montserrat 700 instead of Poppins

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6d413bc088327b6db85a3ad2831a3