### PR TITLE
Fix tokenomics total to 100%

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,10 +275,6 @@
           <i class="material-symbols-outlined">trending_up</i
           ><span data-i18n="tok_list6">투자자: {investors}%</span>
         </li>
-        <li>
-          <i class="material-symbols-outlined">local_fire_department</i
-          ><span data-i18n="tok_list7">전송 소각: {burn}%</span>
-        </li>
       </ul>
     </section>
 

--- a/main.js
+++ b/main.js
@@ -162,7 +162,7 @@ function replaceTokenomicsPlaceholders(root, data) {
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
   while (walker.nextNode()) {
     walker.currentNode.textContent = walker.currentNode.textContent.replace(
-      /\{(supply|dao|community|team|advisors|investors|burn)\}/g,
+      /\{(supply|dao|community|team|advisors|investors)\}/g,
       (_, key) => {
         const value = data[key];
         if (value === undefined) return '';

--- a/tokenomics.json
+++ b/tokenomics.json
@@ -4,6 +4,5 @@
   "community": 20,
   "team": 15,
   "advisors": 5,
-  "investors": 10,
-  "burn": 3
+  "investors": 10
 }


### PR DESCRIPTION
## Summary
- remove burn field from tokenomics so allocations add up to 100%
- drop burn entry from tokenomics list and placeholder handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6d461ca1c8327a87471aa82361d76