### PR TITLE
feat: expose heading semantics

### DIFF
--- a/main.js
+++ b/main.js
@@ -91,6 +91,9 @@ class HCFancyTitle extends HTMLElement {
     `;
     root.appendChild(style);
 
+    this.setAttribute('role', 'heading');
+    this.setAttribute('aria-level', size === 'medium' ? '2' : '1');
+
     const h1 = document.createElement('h1');
     h1.textContent = text;
     h1.setAttribute('data-text', text);


### PR DESCRIPTION
## Summary
- add heading semantics to `hc-fancy-title`
- set `aria-level` based on size before the internal `<h1>` is inserted

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7cc9c250c8327a3d6668d28e3ff81