### PR TITLE
feat: localize notice messages

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -95,5 +95,7 @@
   "title_corporate": "الهوية المؤسسية لـ Hallyu Chain",
   "staking_title": "التخزين والمكافآت",
   "staking_total": "إجمالي التخزين",
-  "staking_rewards": "مكافآتك"
+  "staking_rewards": "مكافآتك",
+  "notice_load_fail": "فشل تحميل الترجمة.",
+  "notice_lang_unavailable": "اللغة المختارة غير متاحة. سيتم استخدام اللغة الافتراضية."
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -95,5 +95,7 @@
   "title_corporate": "Hallyu Chain Corporate Identity",
   "staking_title": "Staking & Belohnungen",
   "staking_total": "Gesamt gestaket",
-  "staking_rewards": "Deine Belohnungen"
+  "staking_rewards": "Deine Belohnungen",
+  "notice_load_fail": "Lokalisierung konnte nicht geladen werden.",
+  "notice_lang_unavailable": "Ausgewählte Sprache nicht verfügbar. Standardsprache wird verwendet."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -95,5 +95,7 @@
   "title_corporate": "Hallyu Chain Corporate Identity",
   "staking_title": "Staking & Rewards",
   "staking_total": "Total Staked",
-  "staking_rewards": "Your Rewards"
+  "staking_rewards": "Your Rewards",
+  "notice_load_fail": "Localization failed to load.",
+  "notice_lang_unavailable": "Selected language unavailable. Using default language."
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -95,5 +95,7 @@
   "title_corporate": "Identidad corporativa de Hallyu Chain",
   "staking_title": "Staking y Recompensas",
   "staking_total": "Total Acumulado",
-  "staking_rewards": "Tus Recompensas"
+  "staking_rewards": "Tus Recompensas",
+  "notice_load_fail": "No se pudo cargar la localización.",
+  "notice_lang_unavailable": "El idioma seleccionado no está disponible. Se usará el idioma predeterminado."
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -95,5 +95,7 @@
   "title_corporate": "Identité corporative Hallyu Chain",
   "staking_title": "Staking et Récompenses",
   "staking_total": "Total Staké",
-  "staking_rewards": "Vos Récompenses"
+  "staking_rewards": "Vos Récompenses",
+  "notice_load_fail": "Échec du chargement de la localisation.",
+  "notice_lang_unavailable": "Langue sélectionnée indisponible. Utilisation de la langue par défaut."
 }

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -95,5 +95,7 @@
   "title_corporate": "Hallyu Chain कॉर्पोरेट पहचान",
   "staking_title": "स्टेकिंग और रिवॉर्ड",
   "staking_total": "कुल स्टेक",
-  "staking_rewards": "आपके रिवॉर्ड"
+  "staking_rewards": "आपके रिवॉर्ड",
+  "notice_load_fail": "स्थानीयकरण लोड करने में विफल।",
+  "notice_lang_unavailable": "चयनित भाषा उपलब्ध नहीं है। डिफ़ॉल्ट भाषा का उपयोग किया जाएगा।"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -95,5 +95,7 @@
   "title_corporate": "Hallyu Chain コーポレートアイデンティティ",
   "staking_title": "ステーキングと報酬",
   "staking_total": "総ステーク量",
-  "staking_rewards": "あなたの報酬"
+  "staking_rewards": "あなたの報酬",
+  "notice_load_fail": "ローカライゼーションの読み込みに失敗しました。",
+  "notice_lang_unavailable": "選択した言語は利用できません。デフォルトの言語を使用します。"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -95,5 +95,7 @@
   "title_corporate": "한류 체인 기업 아이덴티티",
   "staking_title": "스테이킹 및 리워드",
   "staking_total": "총 스테이킹",
-  "staking_rewards": "내 보상"
+  "staking_rewards": "내 보상",
+  "notice_load_fail": "로컬라이제이션을 불러오지 못했습니다.",
+  "notice_lang_unavailable": "선택한 언어를 사용할 수 없습니다. 기본 언어로 표시됩니다."
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -95,5 +95,7 @@
   "title_corporate": "Identidade corporativa Hallyu Chain",
   "staking_title": "Staking e Recompensas",
   "staking_total": "Total em Staking",
-  "staking_rewards": "Suas Recompensas"
+  "staking_rewards": "Suas Recompensas",
+  "notice_load_fail": "Falha ao carregar a localização.",
+  "notice_lang_unavailable": "Idioma selecionado indisponível. Usando o idioma padrão."
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -95,5 +95,7 @@
   "title_corporate": "Корпоративный стиль Hallyu Chain",
   "staking_title": "Стейкинг и награды",
   "staking_total": "Всего застейкано",
-  "staking_rewards": "Ваши награды"
+  "staking_rewards": "Ваши награды",
+  "notice_load_fail": "Не удалось загрузить локализацию.",
+  "notice_lang_unavailable": "Выбранный язык недоступен. Используется язык по умолчанию."
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -95,5 +95,7 @@
   "title_corporate": "Hallyu Chain 企业形象",
   "staking_title": "质押与奖励",
   "staking_total": "总质押量",
-  "staking_rewards": "你的奖励"
+  "staking_rewards": "你的奖励",
+  "notice_load_fail": "加载本地化失败。",
+  "notice_lang_unavailable": "所选语言不可用，已使用默认语言。"
 }

--- a/main.js
+++ b/main.js
@@ -25,7 +25,12 @@ notice.setAttribute('aria-live', 'polite');
 notice.hidden = true;
 document.body.appendChild(notice);
 let noticeTimeout;
-function showNotice(message, delay = 4000) {
+function showNotice(key, delay = 4000, lang = currentLang) {
+  const message =
+    translations[lang]?.[key] ||
+    translations[DEFAULT_LANG]?.[key] ||
+    FALLBACK_NOTICES[key] ||
+    key;
   notice.textContent = message;
   notice.hidden = false;
   clearTimeout(noticeTimeout);
@@ -147,6 +152,10 @@ if (!prefersReducedMotion) {
 
 const translations = {};
 const DEFAULT_LANG = 'en';
+const FALLBACK_NOTICES = {
+  notice_load_fail: 'Localization failed to load.',
+  notice_lang_unavailable: 'Selected language unavailable. Using default language.',
+};
 let tokenomicsCache = null;
 
 async function loadTokenomics() {
@@ -201,13 +210,14 @@ async function loadLanguage(lang) {
 async function setLanguage(lang) {
   const loadedLang = await loadLanguage(lang);
   if (!loadedLang) {
-    showNotice('Localization failed to load.');
+    showNotice('notice_load_fail', 4000, DEFAULT_LANG);
     return;
   }
   if (loadedLang !== lang) {
-    showNotice('Selected language unavailable. Using default language.');
+    showNotice('notice_lang_unavailable', 4000, loadedLang);
   }
   lang = loadedLang;
+  currentLang = lang;
   localStorage.setItem('lang', lang);
   document.documentElement.lang = lang;
   document.querySelectorAll('[data-i18n]').forEach((el) => {
@@ -255,7 +265,7 @@ async function setLanguage(lang) {
   if (select) select.value = lang;
 }
 
-const currentLang = localStorage.getItem('lang') || DEFAULT_LANG;
+let currentLang = localStorage.getItem('lang') || DEFAULT_LANG;
 setLanguage(currentLang);
 
 async function loadWhitepaper(lang) {


### PR DESCRIPTION
## Summary
- add notice message keys across all locales
- translate `showNotice` calls and update language handling
- keep track of active language for notices

## Testing
- `npm run check-locales`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7cd2d22008327a0048dafa26d01ad