### PR TITLE
Use showNotice for metaverse purchase feedback

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,7 +26,7 @@ notice.setAttribute('aria-live', 'polite');
 notice.hidden = true;
 document.body.appendChild(notice);
 let noticeTimeout;
-function showNotice(key, delay = 4000, lang = currentLang) {
+export function showNotice(key, delay = 4000, lang = currentLang) {
   const message =
     translations[lang]?.[key] ||
     translations[DEFAULT_LANG]?.[key] ||
@@ -39,6 +39,10 @@ function showNotice(key, delay = 4000, lang = currentLang) {
     notice.hidden = true;
     notice.textContent = '';
   }, delay);
+}
+// Expose for non-module scripts if needed
+if (typeof window !== 'undefined') {
+  window.showNotice = showNotice;
 }
 
 class HCFancyTitle extends HTMLElement {

--- a/metaverse.js
+++ b/metaverse.js
@@ -1,4 +1,5 @@
 import { ethers } from "https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.esm.min.js";
+import { showNotice } from "./main.js";
 
 const marketAddress = "0x0000000000000000000000000000000000000000"; // replace with deployed address
 const marketAbi = [
@@ -7,24 +8,24 @@ const marketAbi = [
 
 async function purchaseItem(itemId) {
   if (!window.ethereum) {
-    alert("Wallet not found");
+    showNotice("Wallet not found");
     return;
   }
   const provider = new ethers.BrowserProvider(window.ethereum);
   const signer = await provider.getSigner();
   const contract = new ethers.Contract(marketAddress, marketAbi, signer);
-  await contract.purchase(itemId);
+  try {
+    await contract.purchase(itemId);
+    showNotice(`Purchased item ${itemId}`);
+  } catch (err) {
+    console.error(err);
+    showNotice('Purchase failed');
+  }
 }
 
 document.querySelectorAll('[data-item-id]').forEach((btn) => {
-  btn.addEventListener('click', async () => {
+  btn.addEventListener('click', () => {
     const itemId = parseInt(btn.dataset.itemId, 10);
-    try {
-      await purchaseItem(itemId);
-      alert(`Purchased item ${itemId}`);
-    } catch (err) {
-      console.error(err);
-      alert('Purchase failed');
-    }
+    purchaseItem(itemId);
   });
 });


### PR DESCRIPTION
## Summary
- export `showNotice` from `main.js` and expose globally for reuse
- replace purchase alerts in `metaverse.js` with `showNotice`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7cfdb73288327b6a92c670518d878