### PR TITLE
Handle newsletter language fallback gracefully

### DIFF
--- a/main.js
+++ b/main.js
@@ -443,8 +443,11 @@ if (newsletterForm && newsletterMessage) {
   newsletterForm.addEventListener('submit', async (e) => {
     e.preventDefault();
     const lang = localStorage.getItem('lang') || DEFAULT_LANG;
-    await loadLanguage(lang);
-    newsletterMessage.textContent = translations[lang].newsletter_success;
+    // Load the selected language and use the resolved value to handle fallbacks
+    const resolvedLang = (await loadLanguage(lang)) || DEFAULT_LANG;
+    newsletterMessage.textContent =
+      translations[resolvedLang]?.newsletter_success ||
+      translations[DEFAULT_LANG].newsletter_success;
     newsletterMessage.hidden = false;
     clearTimeout(newsletterTimeout);
     newsletterTimeout = setTimeout(() => {


### PR DESCRIPTION
## Summary
- Load and resolve locale before showing newsletter sign-up success messages
- Default to English newsletter message if desired locale fails to load

## Testing
- `npm test`
- `npm run check-locales`

------
https://chatgpt.com/codex/tasks/task_e_68a7d1ff0c2c8327a0a2194bdba1bdb9