### PR TITLE
feat: add i18n support

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,8 +11,10 @@
   },
   "dependencies": {
     "gsap": "^3.13.0",
+    "i18next": "^25.4.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-i18next": "^15.7.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
@@ -23,7 +25,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
-    "vite": "^7.1.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vite": "^7.1.2"
   }
 }

--- a/frontend/src/components/BackToTop.tsx
+++ b/frontend/src/components/BackToTop.tsx
@@ -1,12 +1,14 @@
 import { useBackToTop } from '../hooks/useBackToTop'
+import { useTranslation } from 'react-i18next'
 
 function BackToTop() {
   const { visible, scrollToTop } = useBackToTop()
+  const { t } = useTranslation()
   return (
     <button
       className={`back-to-top ${visible ? 'visible' : ''}`}
       onClick={scrollToTop}
-      aria-label="Back to top"
+      aria-label={t('back_to_top')}
     >
       <i className="material-symbols-outlined" aria-hidden="true">
         arrow_upward

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react'
 import gsap from 'gsap'
+import { useTranslation, Trans } from 'react-i18next'
 
 function Hero() {
   const heroRef = useRef<HTMLElement>(null)
   const titleRef = useRef<HTMLElement>(null)
+  const { t } = useTranslation()
 
   useEffect(() => {
     const hero = heroRef.current
@@ -37,14 +39,13 @@ function Hero() {
       <hc-fancy-title
         className="hero-title"
         ref={titleRef as any}
-        text="Hallyu Chain"
-        data-i18n="hero_title"
+        text={t('hero_title')}
       ></hc-fancy-title>
-      <p data-i18n="hero_subtitle">
-        글로벌 K-POP 커뮤니티를 위한 차세대 블록체인 네트워크
+      <p>
+        <Trans i18nKey="hero_subtitle" />
       </p>
-      <a href="#whitepaper" className="btn" data-i18n="hero_button">
-        백서 보기
+      <a href="#whitepaper" className="btn">
+        <Trans i18nKey="hero_button" />
       </a>
     </header>
   )

--- a/frontend/src/components/LanguageProvider.tsx
+++ b/frontend/src/components/LanguageProvider.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, useState, type ReactNode } from 'react'
+import i18n from '../i18n'
+
+interface LangContext {
+  lang: string
+  changeLang: (lng: string) => void
+}
+
+const LanguageContext = createContext<LangContext>({ lang: i18n.language, changeLang: () => {} })
+
+export function useLanguage() {
+  return useContext(LanguageContext)
+}
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [lang, setLang] = useState(i18n.language)
+
+  const changeLang = (lng: string) => {
+    i18n.changeLanguage(lng)
+    setLang(lng)
+  }
+
+  return (
+    <LanguageContext.Provider value={{ lang, changeLang }}>
+      {children}
+    </LanguageContext.Provider>
+  )
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,13 +1,17 @@
 import { useRef } from 'react'
+import { useTranslation, Trans } from 'react-i18next'
 import { useNavHeight } from '../hooks/useNavHeight'
 import { useTheme } from '../hooks/useTheme'
 import { useNotice } from './NoticeProvider'
+import { useLanguage } from './LanguageProvider'
 
 function Navbar() {
   const navRef = useRef<HTMLElement>(null)
   useNavHeight(navRef)
   const { theme, toggleTheme } = useTheme()
   const showNotice = useNotice()
+  const { t } = useTranslation()
+  const { lang, changeLang } = useLanguage()
 
   const handleTheme = () => {
     toggleTheme()
@@ -32,87 +36,115 @@ function Navbar() {
         <li>
           <a href="#about">
             <i className="material-symbols-outlined">info</i>
-            <span data-i18n="nav_about">소개</span>
+            <span>
+              <Trans i18nKey="nav_about" />
+            </span>
           </a>
         </li>
         <li>
           <a href="#technology">
             <i className="material-symbols-outlined">memory</i>
-            <span data-i18n="nav_technology">기술</span>
+            <span>
+              <Trans i18nKey="nav_technology" />
+            </span>
           </a>
         </li>
         <li>
           <a href="#tokenomics">
             <i className="material-symbols-outlined">paid</i>
-            <span data-i18n="nav_tokenomics">토큰 이코노미</span>
+            <span>
+              <Trans i18nKey="nav_tokenomics" />
+            </span>
           </a>
         </li>
         <li>
           <a href="#roadmap">
             <i className="material-symbols-outlined">map</i>
-            <span data-i18n="nav_roadmap">로드맵</span>
+            <span>
+              <Trans i18nKey="nav_roadmap" />
+            </span>
           </a>
         </li>
         <li>
           <a href="#dao">
             <i className="material-symbols-outlined">groups</i>
-            <span data-i18n="nav_dao">DAO</span>
+            <span>
+              <Trans i18nKey="nav_dao" />
+            </span>
           </a>
         </li>
         <li>
           <a href="#partners">
             <i className="material-symbols-outlined">handshake</i>
-            <span data-i18n="nav_partners">파트너</span>
+            <span>
+              <Trans i18nKey="nav_partners" />
+            </span>
           </a>
         </li>
         <li>
           <a href="#resources">
             <i className="material-symbols-outlined">menu_book</i>
-            <span data-i18n="nav_resources">참고 자료</span>
+            <span>
+              <Trans i18nKey="nav_resources" />
+            </span>
           </a>
         </li>
         <li>
           <a href="#newsletter">
             <i className="material-symbols-outlined">mail</i>
-            <span data-i18n="nav_newsletter">뉴스레터</span>
+            <span>
+              <Trans i18nKey="nav_newsletter" />
+            </span>
           </a>
         </li>
         <li>
           <a href="#faq">
             <i className="material-symbols-outlined">help</i>
-            <span data-i18n="nav_faq">FAQ</span>
+            <span>
+              <Trans i18nKey="nav_faq" />
+            </span>
           </a>
         </li>
         <li>
           <a href="#corporate">
             <i className="material-symbols-outlined">apartment</i>
-            <span data-i18n="nav_corporate">기업 아이덴티티</span>
+            <span>
+              <Trans i18nKey="nav_corporate" />
+            </span>
           </a>
         </li>
         <li>
           <a href="#team">
             <i className="material-symbols-outlined">group</i>
-            <span data-i18n="nav_team">팀</span>
+            <span>
+              <Trans i18nKey="nav_team" />
+            </span>
           </a>
         </li>
         <li>
           <a href="#whitepaper">
             <i className="material-symbols-outlined">description</i>
-            <span data-i18n="nav_whitepaper">백서</span>
+            <span>
+              <Trans i18nKey="nav_whitepaper" />
+            </span>
           </a>
         </li>
       </ul>
       <button
         className="theme-toggle"
-        aria-label="테마 전환"
-        data-i18n-aria-label="nav_theme"
+        aria-label={t('nav_theme')}
         onClick={handleTheme}
       >
         <i className="material-symbols-outlined">
           {theme === 'dark' ? 'light_mode' : 'dark_mode'}
         </i>
       </button>
-      <select className="lang-select" aria-label="Change language">
+      <select
+        className="lang-select"
+        aria-label="Change language"
+        value={lang}
+        onChange={(e) => changeLang(e.target.value)}
+      >
         <option value="ko">🇰🇷</option>
         <option value="en">🇺🇸</option>
         <option value="zh">🇨🇳</option>

--- a/frontend/src/components/Tokenomics.tsx
+++ b/frontend/src/components/Tokenomics.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react'
 import gsap from 'gsap'
 import { ScrollTrigger } from 'gsap/ScrollTrigger'
+import { Trans } from 'react-i18next'
+import tok from '../../../tokenomics.json'
 
 gsap.registerPlugin(ScrollTrigger)
 
@@ -25,31 +27,45 @@ function Tokenomics() {
 
   return (
     <section id="tokenomics" ref={sectionRef}>
-      <h2 data-i18n="tokenomics_title">토큰 이코노미</h2>
+      <h2>
+        <Trans i18nKey="tokenomics_title" />
+      </h2>
       <ul className="icon-list">
         <li>
           <i className="material-symbols-outlined">pie_chart</i>
-          <span data-i18n="tok_list1">총 발행량: {'{supply}'} HALL</span>
+          <span>
+            <Trans i18nKey="tok_list1" values={{ supply: tok.supply }} />
+          </span>
         </li>
         <li>
           <i className="material-symbols-outlined">account_balance</i>
-          <span data-i18n="tok_list2">DAO 재무금고: {'{dao}'}%</span>
+          <span>
+            <Trans i18nKey="tok_list2" values={{ dao: tok.dao }} />
+          </span>
         </li>
         <li>
           <i className="material-symbols-outlined">card_giftcard</i>
-          <span data-i18n="tok_list3">커뮤니티 리워드: {'{community}'}%</span>
+          <span>
+            <Trans i18nKey="tok_list3" values={{ community: tok.community }} />
+          </span>
         </li>
         <li>
           <i className="material-symbols-outlined">groups</i>
-          <span data-i18n="tok_list4">팀: {'{team}'}%</span>
+          <span>
+            <Trans i18nKey="tok_list4" values={{ team: tok.team }} />
+          </span>
         </li>
         <li>
           <i className="material-symbols-outlined">support_agent</i>
-          <span data-i18n="tok_list5">자문단: {'{advisors}'}%</span>
+          <span>
+            <Trans i18nKey="tok_list5" values={{ advisors: tok.advisors }} />
+          </span>
         </li>
         <li>
           <i className="material-symbols-outlined">trending_up</i>
-          <span data-i18n="tok_list6">투자자: {'{investors}'}%</span>
+          <span>
+            <Trans i18nKey="tok_list6" values={{ investors: tok.investors }} />
+          </span>
         </li>
       </ul>
     </section>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,0 +1,37 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+import ar from '../../locales/ar.json'
+import de from '../../locales/de.json'
+import en from '../../locales/en.json'
+import es from '../../locales/es.json'
+import fr from '../../locales/fr.json'
+import hi from '../../locales/hi.json'
+import ja from '../../locales/ja.json'
+import ko from '../../locales/ko.json'
+import pt from '../../locales/pt.json'
+import ru from '../../locales/ru.json'
+import zh from '../../locales/zh.json'
+
+const resources = {
+  ar: { translation: ar },
+  de: { translation: de },
+  en: { translation: en },
+  es: { translation: es },
+  fr: { translation: fr },
+  hi: { translation: hi },
+  ja: { translation: ja },
+  ko: { translation: ko },
+  pt: { translation: pt },
+  ru: { translation: ru },
+  zh: { translation: zh },
+}
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+})
+
+export default i18n

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,17 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './style.css'
+import './i18n'
 import App from './App'
 import { NoticeProvider } from './components/NoticeProvider'
+import { LanguageProvider } from './components/LanguageProvider'
 
 createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>
-    <NoticeProvider>
-      <App />
-    </NoticeProvider>
+    <LanguageProvider>
+      <NoticeProvider>
+        <App />
+      </NoticeProvider>
+    </LanguageProvider>
   </StrictMode>,
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,10 @@
       "version": "0.0.0",
       "dependencies": {
         "gsap": "^3.13.0",
+        "i18next": "^25.4.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-i18next": "^15.7.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -344,6 +346,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -6326,6 +6337,15 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -6355,6 +6375,37 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.4.0.tgz",
+      "integrity": "sha512-UH5aiamXsO3cfrZFurCHiB6YSs3C+s+XY9UaJllMMSbmaoXILxFgqDEZu4NbfzJFjmUo3BNMa++Rjkr3ofjfLw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -7997,6 +8048,32 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.1.tgz",
+      "integrity": "sha512-o4VsKh30fy7p0z5ACHuyWqB6xu9WpQIQy2/ZcbCqopNnrnTVOPn/nAv9uYP4xYAWg99QMpvZ9Bu/si3eGurzGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.4.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -9608,7 +9685,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -9950,6 +10027,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/web3-utils": {


### PR DESCRIPTION
## Summary
- install i18next and react-i18next
- create i18n setup with JSON locale resources
- replace data-i18n attributes with `<Trans>` and context-driven language selector

## Testing
- `npm run lint --workspace frontend`
- `npm run check-locales`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7d75963948327b835f7922197be0c