### PR TITLE
Configure frontend subdirectory build and add deploy workflow

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,0 +1,25 @@
+name: Build and Deploy Frontend
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build --workspace frontend
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: frontend/dist
+          destination_dir: frontend
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "serve": "vite preview"
   },
   "dependencies": {
     "gsap": "^3.13.0",

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/frontend/',
 })

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "check-locales": "node scripts/check-locales.js",
     "dev:frontend": "npm run dev --workspace frontend",
     "dev:backend": "npx hardhat node",
-    "dev": "npm run dev:backend & npm run dev:frontend"
+    "dev": "npm run dev:backend & npm run dev:frontend",
+    "serve": "npm run serve --workspace frontend"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- configure Vite to build assets under `/frontend/`
- add `serve` script and root shortcut for previewing compiled frontend
- add GitHub Actions workflow to build frontend and publish to `gh-pages`

## Testing
- `npm test`
- `npm run build --workspace frontend`
- `npm run lint` *(fails: 160 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a7db8b3e9c8327b7836a31b2af12c6