### PR TITLE
Use SafeERC20 in MetaverseMarket and add failing token tests

### DIFF
--- a/contracts/MetaverseMarket.sol
+++ b/contracts/MetaverseMarket.sol
@@ -2,11 +2,14 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title MetaverseMarket
 /// @notice Simple marketplace for virtual items using HALL tokens as payment
 contract MetaverseMarket is Ownable {
+    using SafeERC20 for IERC20;
+
     IERC20 public immutable paymentToken;
 
     mapping(uint256 => uint256) public itemPrices;
@@ -28,7 +31,7 @@ contract MetaverseMarket is Ownable {
     function purchase(uint256 itemId) external {
         uint256 price = itemPrices[itemId];
         require(price > 0, "Item not for sale");
-        paymentToken.transferFrom(msg.sender, owner(), price);
+        paymentToken.safeTransferFrom(msg.sender, owner(), price);
         emit ItemPurchased(msg.sender, itemId, price);
     }
 }

--- a/contracts/NonStandardToken.sol
+++ b/contracts/NonStandardToken.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @dev ERC20 token whose transferFrom always fails by returning false.
+contract NonStandardToken is ERC20 {
+    constructor() ERC20("NonStandardToken", "NST") {
+        _mint(msg.sender, 1_000_000 * 10 ** decimals());
+    }
+
+    // Intentionally non-standard: does not revert but returns false instead of transferring
+    function transferFrom(address, address, uint256) public override returns (bool) {
+        return false;
+    }
+}

--- a/test/MetaverseMarket.js
+++ b/test/MetaverseMarket.js
@@ -1,0 +1,31 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("MetaverseMarket", function () {
+  let buyer, token, market;
+  const itemId = 1;
+  const price = ethers.parseUnits("10", 18);
+
+  beforeEach(async function () {
+    [, buyer] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("NonStandardToken");
+    token = await Token.deploy();
+    await token.waitForDeployment();
+
+    const Market = await ethers.getContractFactory("MetaverseMarket");
+    market = await Market.deploy(await token.getAddress());
+    await market.waitForDeployment();
+
+    await market.setItemPrice(itemId, price);
+    await token.transfer(buyer.address, price);
+    await token.connect(buyer).approve(await market.getAddress(), price);
+  });
+
+  it("reverts when payment token transfer fails", async function () {
+    await expect(
+      market.connect(buyer).purchase(itemId)
+    ).to.be.revertedWithCustomError(market, "SafeERC20FailedOperation").withArgs(
+      await token.getAddress()
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Secure MetaverseMarket payments by importing SafeERC20 and using `safeTransferFrom`
- Introduce `NonStandardToken` that returns false on transfers to mimic non-compliant tokens
- Add test ensuring purchases revert when payment token fails to transfer

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7e39f84ec8327a06209d0a5b71a33