### PR TITLE
Use SafeERC20 in NFTStaking and add tests

### DIFF
--- a/contracts/NFTStaking.sol
+++ b/contracts/NFTStaking.sol
@@ -3,11 +3,14 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title NFT Staking for Hallyu NFT holders
 /// @notice Stake NFTs to earn HALL token rewards and gain metaverse privileges
 contract NFTStaking is Ownable {
+    using SafeERC20 for IERC20;
+
     IERC721 public immutable nft;
     IERC20 public immutable rewardToken;
     uint256 public rewardRate; // reward per second per NFT (in token wei)
@@ -24,6 +27,7 @@ contract NFTStaking is Ownable {
     event Staked(address indexed user, uint256 indexed tokenId);
     event Unstaked(address indexed user, uint256 indexed tokenId);
     event RewardPaid(address indexed user, uint256 reward);
+    event RewardRateUpdated(uint256 newRate);
 
     constructor(address _nft, address _rewardToken, uint256 _rewardRate) Ownable(msg.sender) {
         nft = IERC721(_nft);
@@ -58,7 +62,7 @@ contract NFTStaking is Ownable {
     function claim() external updateReward(msg.sender) {
         uint256 reward = stakers[msg.sender].rewards;
         stakers[msg.sender].rewards = 0;
-        rewardToken.transfer(msg.sender, reward);
+        rewardToken.safeTransfer(msg.sender, reward);
         emit RewardPaid(msg.sender, reward);
     }
 
@@ -74,6 +78,7 @@ contract NFTStaking is Ownable {
 
     function setRewardRate(uint256 _rate) external onlyOwner {
         rewardRate = _rate;
+        emit RewardRateUpdated(_rate);
     }
 }
 

--- a/contracts/NonStandardToken.sol
+++ b/contracts/NonStandardToken.sol
@@ -3,13 +3,17 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-/// @dev ERC20 token whose transferFrom always fails by returning false.
+/// @dev ERC20 token whose transfer and transferFrom always fail by returning false.
 contract NonStandardToken is ERC20 {
     constructor() ERC20("NonStandardToken", "NST") {
         _mint(msg.sender, 1_000_000 * 10 ** decimals());
     }
 
     // Intentionally non-standard: does not revert but returns false instead of transferring
+    function transfer(address, uint256) public override returns (bool) {
+        return false;
+    }
+
     function transferFrom(address, address, uint256) public override returns (bool) {
         return false;
     }

--- a/test/NFTStaking.js
+++ b/test/NFTStaking.js
@@ -1,0 +1,95 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { anyValue } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
+
+describe("NFTStaking", function () {
+  it("emits RewardPaid on successful claim", async function () {
+    const [owner, user] = await ethers.getSigners();
+
+    const NFT = await ethers.getContractFactory("HallyuNFT");
+    const nft = await NFT.deploy();
+    await nft.waitForDeployment();
+
+    const Token = await ethers.getContractFactory("HallyuToken");
+    const token = await Token.deploy(owner.address);
+    await token.waitForDeployment();
+
+    const Staking = await ethers.getContractFactory("NFTStaking");
+    const staking = await Staking.deploy(
+      await nft.getAddress(),
+      await token.getAddress(),
+      ethers.parseUnits("1", 18)
+    );
+    await staking.waitForDeployment();
+
+    await nft.mint(user.address, "");
+    await nft.connect(user).approve(await staking.getAddress(), 0);
+    await staking.connect(user).stake(0);
+
+    const deposit = ethers.parseUnits("2000", 18);
+    await token.transfer(await staking.getAddress(), deposit);
+
+    await ethers.provider.send("evm_increaseTime", [1000]);
+    await ethers.provider.send("evm_mine", []);
+
+    await expect(staking.connect(user).claim())
+      .to.emit(staking, "RewardPaid")
+      .withArgs(user.address, anyValue);
+  });
+
+  it("reverts when reward token transfer fails", async function () {
+    const [owner, user] = await ethers.getSigners();
+
+    const NFT = await ethers.getContractFactory("HallyuNFT");
+    const nft = await NFT.deploy();
+    await nft.waitForDeployment();
+
+    const BadToken = await ethers.getContractFactory("NonStandardToken");
+    const badToken = await BadToken.deploy();
+    await badToken.waitForDeployment();
+
+    const Staking = await ethers.getContractFactory("NFTStaking");
+    const staking = await Staking.deploy(
+      await nft.getAddress(),
+      await badToken.getAddress(),
+      ethers.parseUnits("1", 18)
+    );
+    await staking.waitForDeployment();
+
+    await nft.mint(user.address, "");
+    await nft.connect(user).approve(await staking.getAddress(), 0);
+    await staking.connect(user).stake(0);
+
+    await ethers.provider.send("evm_increaseTime", [1000]);
+    await ethers.provider.send("evm_mine", []);
+
+    await expect(staking.connect(user).claim())
+      .to.be.revertedWithCustomError(staking, "SafeERC20FailedOperation")
+      .withArgs(await badToken.getAddress());
+  });
+
+  it("emits RewardRateUpdated when rate changes", async function () {
+    const [owner] = await ethers.getSigners();
+
+    const NFT = await ethers.getContractFactory("HallyuNFT");
+    const nft = await NFT.deploy();
+    await nft.waitForDeployment();
+
+    const Token = await ethers.getContractFactory("HallyuToken");
+    const token = await Token.deploy(owner.address);
+    await token.waitForDeployment();
+
+    const Staking = await ethers.getContractFactory("NFTStaking");
+    const staking = await Staking.deploy(
+      await nft.getAddress(),
+      await token.getAddress(),
+      0n
+    );
+    await staking.waitForDeployment();
+
+    const newRate = ethers.parseUnits("2", 18);
+    await expect(staking.setRewardRate(newRate))
+      .to.emit(staking, "RewardRateUpdated")
+      .withArgs(newRate);
+  });
+});


### PR DESCRIPTION
## Summary
- secure NFT reward payouts with SafeERC20 and new RewardRateUpdated event
- expand NonStandardToken and add NFTStaking tests for events and transfer failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7e6b8a67883279db69ef06087a28b