### PR TITLE
feat: emit conversion rate update

### DIFF
--- a/contracts/CommunityRewards.sol
+++ b/contracts/CommunityRewards.sol
@@ -12,6 +12,7 @@ contract CommunityRewards is Ownable {
 
     mapping(address => uint256) public points;
 
+    event ConversionRateUpdated(uint256 newRate);
     event PointsAdded(address indexed user, uint256 amount);
     event Redeemed(address indexed user, uint256 points, uint256 hallAmount);
 
@@ -22,6 +23,7 @@ contract CommunityRewards is Ownable {
 
     function setConversionRate(uint256 rate) external onlyOwner {
         conversionRate = rate;
+        emit ConversionRateUpdated(rate);
     }
 
     function addPoints(address user, uint256 amount) external onlyOwner {

--- a/test/CommunityRewards.js
+++ b/test/CommunityRewards.js
@@ -1,0 +1,23 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("CommunityRewards", function () {
+  let owner, token, rewards;
+
+  beforeEach(async function () {
+    [owner] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("HallyuToken");
+    token = await Token.deploy(owner.address);
+    await token.waitForDeployment();
+
+    const CommunityRewards = await ethers.getContractFactory("CommunityRewards");
+    rewards = await CommunityRewards.deploy(token.target, 1n);
+    await rewards.waitForDeployment();
+  });
+
+  it("emits event when conversion rate updates", async function () {
+    await expect(rewards.setConversionRate(2n))
+      .to.emit(rewards, "ConversionRateUpdated")
+      .withArgs(2n);
+  });
+});


### PR DESCRIPTION
## Summary
- add `ConversionRateUpdated` event for `CommunityRewards`
- emit conversion rate update when owner sets a new rate
- test conversion rate updates emit the new event

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7ebff0c488327b5e3ec84f484b205