### PR TITLE
Add burn allocation to tokenomics and update UI

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -90,7 +90,7 @@ function replaceTokenomicsPlaceholders(root, data) {
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
   while (walker.nextNode()) {
     walker.currentNode.textContent = walker.currentNode.textContent.replace(
-      /\{(supply|dao|community|team|advisors|investors)\}/g,
+      /\{(supply|dao|community|team|advisors|investors|burn)\}/g,
       (_, key) => {
         const value = data[key];
         if (value === void 0) return "";

--- a/frontend/src/components/Tokenomics.tsx
+++ b/frontend/src/components/Tokenomics.tsx
@@ -68,6 +68,12 @@ function Tokenomics() {
             <Trans i18nKey="tok_list6" values={{ investors: tok.investors }} />
           </span>
         </li>
+        <li>
+          <i className="material-symbols-outlined">local_fire_department</i>
+          <span>
+            <Trans i18nKey="tok_list7" values={{ burn: tok.burn }} />
+          </span>
+        </li>
       </ul>
     </section>
   )

--- a/index.html
+++ b/index.html
@@ -281,6 +281,10 @@
           <i class="material-symbols-outlined">trending_up</i
           ><span data-i18n="tok_list6">투자자: {investors}%</span>
         </li>
+        <li>
+          <i class="material-symbols-outlined">local_fire_department</i
+          ><span data-i18n="tok_list7">전송 소각: {burn}%</span>
+        </li>
       </ul>
     </section>
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -24,7 +24,7 @@ function replaceTokenomicsPlaceholders(root, data) {
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
   while (walker.nextNode()) {
     walker.currentNode.textContent = walker.currentNode.textContent.replace(
-      /\{(supply|dao|community|team|advisors|investors)\}/g,
+      /\{(supply|dao|community|team|advisors|investors|burn)\}/g,
       (_, key) => {
         const value = data[key];
         if (value === undefined) return '';

--- a/test/NFTStaking.js
+++ b/test/NFTStaking.js
@@ -38,7 +38,7 @@ describe("NFTStaking", function () {
   });
 
   it("reverts when reward token transfer fails", async function () {
-    const [owner, user] = await ethers.getSigners();
+    const [, user] = await ethers.getSigners();
 
     const NFT = await ethers.getContractFactory("HallyuNFT");
     const nft = await NFT.deploy();

--- a/tokenomics.json
+++ b/tokenomics.json
@@ -1,8 +1,9 @@
 {
   "supply": 10000000000,
-  "dao": 50,
+  "dao": 47,
   "community": 20,
   "team": 15,
   "advisors": 5,
-  "investors": 10
+  "investors": 10,
+  "burn": 3
 }


### PR DESCRIPTION
## Summary
- add 3% burn allocation and reduce DAO share to 47% to keep total at 100%
- display burn allocation in tokenomics section and update placeholder logic
- fix unused owner variable in NFTStaking test

## Testing
- `npm run lint`
- `npm run check-locales`
- `npm run test:frontend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7f0798e98832785bd3468dbfc7855