### PR TITLE
Update token allocation percentages

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -72,11 +72,11 @@ async function main() {
   console.log('InvestorVesting deployed to:', investorVestingAddress);
 
   const allocations = {
-    dao: ethers.parseUnits('100000000', 18),
-    communityRewards: ethers.parseUnits('3900000000', 18),
-    team: ethers.parseUnits('2000000000', 18),
-    advisors: ethers.parseUnits('1000000000', 18),
-    investors: ethers.parseUnits('3000000000', 18),
+    dao: ethers.parseUnits('5000000000', 18),
+    communityRewards: ethers.parseUnits('2000000000', 18),
+    team: ethers.parseUnits('1500000000', 18),
+    advisors: ethers.parseUnits('500000000', 18),
+    investors: ethers.parseUnits('1000000000', 18),
   };
 
   await token.transfer(daoAddress, allocations.dao);

--- a/tokenomics.json
+++ b/tokenomics.json
@@ -1,6 +1,6 @@
 {
   "supply": 10000000000,
-  "dao": 47,
+  "dao": 50,
   "community": 20,
   "team": 15,
   "advisors": 5,


### PR DESCRIPTION
## Summary
- Adjust token distribution in deployment script to DAO 50%, Community 20%, Team 15%, Advisors 5%, Investors 10%.
- Align tokenomics metadata with new DAO share.

## Testing
- `npm test`
- `npm run test:frontend`
- `npx hardhat run --no-compile scripts/deploy.js --network hardhat`


------
https://chatgpt.com/codex/tasks/task_e_68a7f20dc9388327a05e527480be8dc4