### PR TITLE
Clear notice timeout on new messages and unmount

### DIFF
--- a/frontend/src/components/NoticeProvider.tsx
+++ b/frontend/src/components/NoticeProvider.tsx
@@ -1,4 +1,12 @@
-import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from 'react'
 import { createPortal } from 'react-dom'
 import styles from './NoticeProvider.module.css'
 
@@ -10,11 +18,23 @@ export function useNotice() {
 
 export function NoticeProvider({ children }: { children: ReactNode }) {
   const [message, setMessage] = useState<string | null>(null)
+  const timeoutId = useRef<number | null>(null)
 
   const showNotice = useCallback((msg: string, delay = 4000) => {
     setMessage(msg)
     if (delay > 0) {
-      setTimeout(() => setMessage(null), delay)
+      if (timeoutId.current !== null) {
+        clearTimeout(timeoutId.current)
+      }
+      timeoutId.current = window.setTimeout(() => setMessage(null), delay)
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (timeoutId.current !== null) {
+        clearTimeout(timeoutId.current)
+      }
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- prevent overlapping timeouts in NoticeProvider by tracking timeout id
- clear timeout before setting a new one and on component unmount

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7f7c1ec248327a966e0796a24cde7