### PR TITLE
feat: lazy load i18n resources

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,37 +1,30 @@
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
-import ar from '../../locales/ar.json'
-import de from '../../locales/de.json'
-import en from '../../locales/en.json'
-import es from '../../locales/es.json'
-import fr from '../../locales/fr.json'
-import hi from '../../locales/hi.json'
-import ja from '../../locales/ja.json'
-import ko from '../../locales/ko.json'
-import pt from '../../locales/pt.json'
-import ru from '../../locales/ru.json'
-import zh from '../../locales/zh.json'
+const translationFiles = import.meta.glob('../../locales/*.json')
 
-const resources = {
-  ar: { translation: ar },
-  de: { translation: de },
-  en: { translation: en },
-  es: { translation: es },
-  fr: { translation: fr },
-  hi: { translation: hi },
-  ja: { translation: ja },
-  ko: { translation: ko },
-  pt: { translation: pt },
-  ru: { translation: ru },
-  zh: { translation: zh },
+const backend = {
+  type: 'backend' as const,
+  init() {},
+  read(language: string, _ns: string, callback: (err: unknown, data: unknown) => void) {
+    const loader = translationFiles[`../../locales/${language}.json`]
+    if (!loader) {
+      callback(new Error(`Missing translation for ${language}`), null)
+      return
+    }
+    loader()
+      .then((mod: any) => callback(null, mod.default))
+      .catch((err: unknown) => callback(err, null))
+  },
 }
 
-i18n.use(initReactI18next).init({
-  resources,
-  lng: 'en',
-  fallbackLng: 'en',
-  interpolation: { escapeValue: false },
-})
+void i18n
+  .use(backend)
+  .use(initReactI18next)
+  .init({
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+  })
 
 export default i18n

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,21 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'node:path'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   base: '/frontend/',
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('/locales/')) {
+            const locale = path.basename(id, '.json')
+            return `locale-${locale}`
+          }
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- dynamically import translation files on demand
- split locale bundles during Vite build

## Testing
- `npm run lint --workspace frontend`
- `npm test`
- `npm run build --workspace frontend`
- `npm run test:frontend` *(fails: import_lru_cache.LRUCache is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f7bc75188327bec37ad7b3467dec