### PR TITLE
Use SafeERC20 and ReentrancyGuard in staking and rewards

### DIFF
--- a/contracts/CommunityRewards.sol
+++ b/contracts/CommunityRewards.sol
@@ -2,11 +2,15 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title CommunityRewards
 /// @notice Converts off-chain activity points to HALL tokens
-contract CommunityRewards is Ownable {
+contract CommunityRewards is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
     IERC20 public immutable token;
     uint256 public conversionRate; // HALL per point (in wei)
 
@@ -31,11 +35,11 @@ contract CommunityRewards is Ownable {
         emit PointsAdded(user, amount);
     }
 
-    function redeem(uint256 amount) external {
+    function redeem(uint256 amount) external nonReentrant {
         require(points[msg.sender] >= amount, "not enough points");
         uint256 hallAmount = amount * conversionRate;
         points[msg.sender] -= amount;
-        require(token.transfer(msg.sender, hallAmount), "transfer failed");
+        token.safeTransfer(msg.sender, hallAmount);
         emit Redeemed(msg.sender, amount, hallAmount);
     }
 }

--- a/contracts/NFTStaking.sol
+++ b/contracts/NFTStaking.sol
@@ -4,11 +4,12 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title NFT Staking for Hallyu NFT holders
 /// @notice Stake NFTs to earn HALL token rewards and gain metaverse privileges
-contract NFTStaking is Ownable {
+contract NFTStaking is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     IERC721 public immutable nft;
@@ -44,7 +45,7 @@ contract NFTStaking is Ownable {
         _;
     }
 
-    function stake(uint256 tokenId) external updateReward(msg.sender) {
+    function stake(uint256 tokenId) external nonReentrant updateReward(msg.sender) {
         nft.transferFrom(msg.sender, address(this), tokenId);
         stakers[msg.sender].balance += 1;
         tokenOwner[tokenId] = msg.sender;
@@ -59,7 +60,7 @@ contract NFTStaking is Ownable {
         emit Unstaked(msg.sender, tokenId);
     }
 
-    function claim() external updateReward(msg.sender) {
+    function claim() external nonReentrant updateReward(msg.sender) {
         uint256 reward = stakers[msg.sender].rewards;
         stakers[msg.sender].rewards = 0;
         rewardToken.safeTransfer(msg.sender, reward);


### PR DESCRIPTION
## Summary
- guard staking and rewards contracts against reentrancy
- use SafeERC20 for all token transfers

## Testing
- `node scripts/offline-compile.js`
- `npx hardhat test --no-compile`

------
https://chatgpt.com/codex/tasks/task_e_68a7f7b1e7cc8327a6af30d3e07bad52