### PR TITLE
Add animation tests for reduced-motion scenarios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint": "^9.33.0",
         "hardhat": "^2.26.3",
         "jsdom": "^24.0.0",
+        "lru-cache": "^10.4.3",
         "prettier": "^3.6.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "1.0.0",
   "description": "This repository contains the marketing website for **Hallyu Chain (HALL)**, a commercial-grade cryptocurrency project built for the global K-POP community.",
   "main": "bundle.js",
-  "workspaces": ["frontend"],
+  "workspaces": [
+    "frontend"
+  ],
   "scripts": {
     "compile": "npx hardhat compile",
     "pretest": "node scripts/offline-compile.js",
-    "test": "npx hardhat test --no-compile",
+    "test": "npx hardhat test --no-compile && TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm --test src/animations.test.js",
     "deploy": "npx hardhat run scripts/deploy.js --network hardhat",
     "multi-deploy": "node scripts/multichain-deploy.js",
     "lint": "eslint .",
@@ -29,17 +31,18 @@
   "type": "commonjs",
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^6.1.0",
-    "eslint": "^9.33.0",
-    "hardhat": "^2.26.3",
-    "prettier": "^3.6.2",
+    "@types/gsap": "^3.0.0",
+    "@types/jsdom": "^21.1.7",
+    "@types/node": "^24.3.0",
     "dotenv": "^16.4.5",
     "esbuild": "^0.21.5",
+    "eslint": "^9.33.0",
+    "hardhat": "^2.26.3",
     "jsdom": "^24.0.0",
-    "typescript": "^5.9.2",
+    "lru-cache": "^10.4.3",
+    "prettier": "^3.6.2",
     "ts-node": "^10.9.2",
-    "@types/node": "^24.3.0",
-    "@types/gsap": "^3.0.0",
-    "@types/jsdom": "^21.1.7"
+    "typescript": "^5.9.2"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.4.0"

--- a/src/animations.test.js
+++ b/src/animations.test.js
@@ -1,0 +1,47 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+function setupDom(prefers) {
+  const dom = new JSDOM('<section id="a"></section>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.window.matchMedia = () => ({
+    matches: prefers,
+    addEventListener: () => {},
+  });
+  global.matchMedia = global.window.matchMedia;
+
+  const calls = [];
+  global.ScrollTrigger = {
+    getAll: () => [],
+  };
+  global.gsap = {
+    registerPlugin: () => {},
+    from: (el, vars) => {
+      el.style.opacity = String(vars.opacity);
+      el.style.transform = `translate(0, ${vars.y}px)`;
+      calls.push({ el, vars });
+    },
+    to: () => {},
+  };
+  return { section: dom.window.document.querySelector('section'), calls };
+}
+
+test('animated sections have styles when motion allowed', async () => {
+  const { section, calls } = setupDom(false);
+  const { initAnimations } = await import('./animations.ts');
+  initAnimations();
+  assert.equal(calls.length, 1);
+  assert.equal(section.style.opacity, '0');
+  assert.notEqual(section.style.transform, '');
+});
+
+test('sections remain visible without animation when motion reduced', async () => {
+  const { section, calls } = setupDom(true);
+  const { initAnimations } = await import('./animations.ts?test=1');
+  initAnimations();
+  assert.equal(calls.length, 0);
+  assert.equal(section.style.opacity, '1');
+  assert.equal(section.style.transform, 'none');
+});


### PR DESCRIPTION
## Summary
- add JSDOM-based tests for animation behavior with and without reduced motion
- run these tests through npm test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7fe104b8c8327a041c95e04daa167