### PR TITLE
feat: add pausable bridge

### DIFF
--- a/test/Bridge.js
+++ b/test/Bridge.js
@@ -29,4 +29,16 @@ describe('Bridge', function () {
       ((amount * BigInt(feeRate)) / 10000n * BigInt(burnRate)) / 10000n; // fee burn
     expect(supplyBefore - supplyAfter).to.equal(expectedBurn);
   });
+
+  it('blocks bridge and release when paused', async function () {
+    await bridge.pause();
+
+    await expect(
+      bridge.bridge(amount, 1, owner.address)
+    ).to.be.revertedWithCustomError(bridge, 'EnforcedPause');
+
+    await expect(
+      bridge.release(owner.address, amount)
+    ).to.be.revertedWithCustomError(bridge, 'EnforcedPause');
+  });
 });


### PR DESCRIPTION
## Summary
- allow Bridge to be paused and unpaused by the owner
- guard bridge and release operations with whenNotPaused
- test that paused bridge blocks operations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8062768a483278229c57e26a156d2