### PR TITLE
Add reward pool management to StakingPool

### DIFF
--- a/contracts/TestToken.sol
+++ b/contracts/TestToken.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @dev Simple ERC20 token for testing purposes.
+contract TestToken is ERC20 {
+    constructor() ERC20("TestToken", "TST") {
+        _mint(msg.sender, 1_000_000 * 10 ** decimals());
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+

--- a/test/StakingPool.js
+++ b/test/StakingPool.js
@@ -1,12 +1,13 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
+const { anyValue } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
 
 describe("StakingPool", function () {
   it("emits InterestRateUpdated when rate changes", async function () {
     const [owner] = await ethers.getSigners();
 
-    const Token = await ethers.getContractFactory("HallyuToken");
-    const token = await Token.deploy(owner.address);
+    const Token = await ethers.getContractFactory("TestToken");
+    const token = await Token.deploy();
     await token.waitForDeployment();
 
     const Pool = await ethers.getContractFactory("StakingPool");
@@ -17,5 +18,57 @@ describe("StakingPool", function () {
     await expect(pool.setInterestRate(newRate))
       .to.emit(pool, "InterestRateUpdated")
       .withArgs(newRate);
+  });
+
+  it("allows owner to deposit and withdraw rewards", async function () {
+    const [owner] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("TestToken");
+    const token = await Token.deploy();
+    await token.waitForDeployment();
+
+    const Pool = await ethers.getContractFactory("StakingPool");
+    const pool = await Pool.deploy(await token.getAddress(), 0n);
+    await pool.waitForDeployment();
+
+    const amount = ethers.parseUnits("100", 18);
+    await token.approve(await pool.getAddress(), amount);
+    await expect(pool.depositRewards(amount))
+      .to.emit(pool, "RewardsDeposited")
+      .withArgs(owner.address, amount);
+
+    const withdrawAmount = ethers.parseUnits("50", 18);
+    await expect(pool.withdrawExcess(withdrawAmount))
+      .to.emit(pool, "ExcessWithdrawn")
+      .withArgs(owner.address, withdrawAmount);
+  });
+
+  it("allows users to claim rewards after funding", async function () {
+    const [owner, user] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("TestToken");
+    const token = await Token.deploy();
+    await token.waitForDeployment();
+
+    const Pool = await ethers.getContractFactory("StakingPool");
+    const rate = ethers.parseUnits("1", 18); // 100% per year
+    const pool = await Pool.deploy(await token.getAddress(), rate);
+    await pool.waitForDeployment();
+
+    const rewardDeposit = ethers.parseUnits("200", 18);
+    await token.approve(await pool.getAddress(), rewardDeposit);
+    await pool.depositRewards(rewardDeposit);
+
+    const stakeAmount = ethers.parseUnits("100", 18);
+    await token.mint(user.address, stakeAmount);
+    await token.connect(user).approve(await pool.getAddress(), stakeAmount);
+    await pool.connect(user).stake(stakeAmount);
+
+    await ethers.provider.send("evm_increaseTime", [365 * 24 * 60 * 60]);
+    await ethers.provider.send("evm_mine", []);
+
+    await expect(pool.connect(user).claim())
+      .to.emit(pool, "RewardPaid")
+      .withArgs(user.address, anyValue);
   });
 });


### PR DESCRIPTION
## Summary
- enable owner to deposit reward tokens and withdraw excess from StakingPool
- add simple TestToken for unit tests
- test reward funding and claiming logic

## Testing
- `npm test`
- `npx hardhat compile` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68a8075f143883279202669629a39398