### PR TITLE
feat: localize whitepaper unavailable notice

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -97,5 +97,6 @@
   "staking_total": "إجمالي التخزين",
   "staking_rewards": "مكافآتك",
   "notice_load_fail": "فشل تحميل الترجمة.",
-  "notice_lang_unavailable": "اللغة المختارة غير متاحة. سيتم استخدام اللغة الافتراضية."
+  "notice_lang_unavailable": "اللغة المختارة غير متاحة. سيتم استخدام اللغة الافتراضية.",
+  "notice_whitepaper_unavailable": "الورقة البيضاء غير متاحة."
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -97,5 +97,6 @@
   "staking_total": "Gesamt gestaket",
   "staking_rewards": "Deine Belohnungen",
   "notice_load_fail": "Lokalisierung konnte nicht geladen werden.",
-  "notice_lang_unavailable": "Ausgewählte Sprache nicht verfügbar. Standardsprache wird verwendet."
+  "notice_lang_unavailable": "Ausgewählte Sprache nicht verfügbar. Standardsprache wird verwendet.",
+  "notice_whitepaper_unavailable": "Whitepaper nicht verfügbar."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -97,5 +97,6 @@
   "staking_total": "Total Staked",
   "staking_rewards": "Your Rewards",
   "notice_load_fail": "Localization failed to load.",
-  "notice_lang_unavailable": "Selected language unavailable. Using default language."
+  "notice_lang_unavailable": "Selected language unavailable. Using default language.",
+  "notice_whitepaper_unavailable": "Whitepaper not available."
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -97,5 +97,6 @@
   "staking_total": "Total Acumulado",
   "staking_rewards": "Tus Recompensas",
   "notice_load_fail": "No se pudo cargar la localización.",
-  "notice_lang_unavailable": "El idioma seleccionado no está disponible. Se usará el idioma predeterminado."
+  "notice_lang_unavailable": "El idioma seleccionado no está disponible. Se usará el idioma predeterminado.",
+  "notice_whitepaper_unavailable": "Libro blanco no disponible."
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -97,5 +97,6 @@
   "staking_total": "Total Staké",
   "staking_rewards": "Vos Récompenses",
   "notice_load_fail": "Échec du chargement de la localisation.",
-  "notice_lang_unavailable": "Langue sélectionnée indisponible. Utilisation de la langue par défaut."
+  "notice_lang_unavailable": "Langue sélectionnée indisponible. Utilisation de la langue par défaut.",
+  "notice_whitepaper_unavailable": "Livre blanc non disponible."
 }

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -97,5 +97,6 @@
   "staking_total": "कुल स्टेक",
   "staking_rewards": "आपके रिवॉर्ड",
   "notice_load_fail": "स्थानीयकरण लोड करने में विफल।",
-  "notice_lang_unavailable": "चयनित भाषा उपलब्ध नहीं है। डिफ़ॉल्ट भाषा का उपयोग किया जाएगा।"
+  "notice_lang_unavailable": "चयनित भाषा उपलब्ध नहीं है। डिफ़ॉल्ट भाषा का उपयोग किया जाएगा।",
+  "notice_whitepaper_unavailable": "श्वेतपत्र उपलब्ध नहीं है।"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -97,5 +97,6 @@
   "staking_total": "総ステーク量",
   "staking_rewards": "あなたの報酬",
   "notice_load_fail": "ローカライゼーションの読み込みに失敗しました。",
-  "notice_lang_unavailable": "選択した言語は利用できません。デフォルトの言語を使用します。"
+  "notice_lang_unavailable": "選択した言語は利用できません。デフォルトの言語を使用します。",
+  "notice_whitepaper_unavailable": "ホワイトペーパーは利用できません。"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -97,5 +97,6 @@
   "staking_total": "총 스테이킹",
   "staking_rewards": "내 보상",
   "notice_load_fail": "로컬라이제이션을 불러오지 못했습니다.",
-  "notice_lang_unavailable": "선택한 언어를 사용할 수 없습니다. 기본 언어로 표시됩니다."
+  "notice_lang_unavailable": "선택한 언어를 사용할 수 없습니다. 기본 언어로 표시됩니다.",
+  "notice_whitepaper_unavailable": "백서를 사용할 수 없습니다."
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -97,5 +97,6 @@
   "staking_total": "Total em Staking",
   "staking_rewards": "Suas Recompensas",
   "notice_load_fail": "Falha ao carregar a localização.",
-  "notice_lang_unavailable": "Idioma selecionado indisponível. Usando o idioma padrão."
+  "notice_lang_unavailable": "Idioma selecionado indisponível. Usando o idioma padrão.",
+  "notice_whitepaper_unavailable": "Whitepaper indisponível."
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -97,5 +97,6 @@
   "staking_total": "Всего застейкано",
   "staking_rewards": "Ваши награды",
   "notice_load_fail": "Не удалось загрузить локализацию.",
-  "notice_lang_unavailable": "Выбранный язык недоступен. Используется язык по умолчанию."
+  "notice_lang_unavailable": "Выбранный язык недоступен. Используется язык по умолчанию.",
+  "notice_whitepaper_unavailable": "Whitepaper недоступен."
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -97,5 +97,6 @@
   "staking_total": "总质押量",
   "staking_rewards": "你的奖励",
   "notice_load_fail": "加载本地化失败。",
-  "notice_lang_unavailable": "所选语言不可用，已使用默认语言。"
+  "notice_lang_unavailable": "所选语言不可用，已使用默认语言。",
+  "notice_whitepaper_unavailable": "白皮书不可用。"
 }

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -2,7 +2,9 @@ import { JSDOM } from 'jsdom';
 import { test } from 'node:test';
 import assert from 'node:assert';
 
-const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost' });
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'http://localhost',
+});
 global.window = dom.window;
 global.document = dom.window.document;
 global.localStorage = dom.window.localStorage;
@@ -12,4 +14,25 @@ test('translate returns key when missing', async () => {
   translations.en = { hello: 'Hello' };
   assert.equal(translate('hello', 'en'), 'Hello');
   assert.equal(translate('unknown', 'en'), 'unknown');
+});
+
+test('loadWhitepaper uses translated fallback', async () => {
+  const { translations, translate, loadWhitepaper } = await import('./i18n.ts');
+  translations.en = {
+    notice_whitepaper_unavailable: 'Whitepaper not available.',
+  };
+  const container = document.createElement('div');
+  container.id = 'whitepaper-content';
+  document.body.appendChild(container);
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({ ok: false, status: 404 });
+  try {
+    await loadWhitepaper('en');
+  } finally {
+    global.fetch = originalFetch;
+  }
+  assert.equal(
+    container.innerHTML,
+    `<p>${translate('notice_whitepaper_unavailable')}</p>`
+  );
 });

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -140,7 +140,7 @@ export async function loadWhitepaper(lang) {
     window.applyFancyTitles?.();
   } catch (err) {
     console.error('Failed to load whitepaper:', err);
-    container.innerHTML = '<p>Whitepaper not available.</p>';
+    container.innerHTML = `<p>${translate('notice_whitepaper_unavailable', lang)}</p>`;
   }
 }
 


### PR DESCRIPTION
## Summary
- add `notice_whitepaper_unavailable` translation across locales
- use translated fallback when whitepaper fails to load
- test whitepaper translation path

## Testing
- `npm run check-locales`
- `npm run test:frontend` *(fails: TypeError: import_lru_cache.LRUCache is not a constructor)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a80a4294088327b143b57986a33f16