### PR TITLE
docs: add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ To maintain consistent spacing across the site, a small scale of custom properti
 
 These tokens drive margins, paddings and gaps for common layout components. The values adjust in media queries to keep spacing proportional on smaller screens.
 
+## Build
+
+Bundle the TypeScript entry point for the static site:
+
+```bash
+npm run build:web
+```
+
+This command outputs `bundle.js` from `src/index.ts`, and the static site loads that file.
+
 ## Local Development
 
 1. Clone the repository and change into the project directory:


### PR DESCRIPTION
## Summary
- document `npm run build:web` for bundling `src/index.ts`
- note that the build outputs `bundle.js` used by the static site

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8184a82e48327adbeea840bfa261a