### PR TITLE
refactor: centralize lru-cache shim for tests

### DIFF
--- a/src/animations.test.js
+++ b/src/animations.test.js
@@ -1,19 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import Module from 'module';
+import { applyLruCacheShim } from './test-helpers/lru-cache-shim.js';
 
-// Shim lru-cache for jsdom on Node 22 (similar to fancy-title tests).
-const originalLoad = Module._load;
-Module._load = function (request, parent, isMain) {
-  if (request === 'lru-cache') {
-    const mod = originalLoad(request, parent, isMain);
-    if (mod && typeof mod === 'function') return { LRUCache: mod };
-    if (mod && typeof mod === 'object' && 'default' in mod)
-      return { LRUCache: mod.default };
-    return mod;
-  }
-  return originalLoad(request, parent, isMain);
-};
+applyLruCacheShim();
 
 const require = Module.createRequire(import.meta.url);
 const { JSDOM } = require('jsdom');

--- a/src/fancy-title.test.js
+++ b/src/fancy-title.test.js
@@ -1,21 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import Module from 'module';
+import { applyLruCacheShim } from './test-helpers/lru-cache-shim.js';
 
-// JSDOM depends on a CommonJS module that requires `lru-cache`.
-// Node 22 ships `lru-cache` as ESM only, so we shim the require
-// to return an object with the expected `LRUCache` export.
-const originalLoad = Module._load;
-Module._load = function (request, parent, isMain) {
-  if (request === 'lru-cache') {
-    const mod = originalLoad(request, parent, isMain);
-    if (mod && typeof mod === 'function') return { LRUCache: mod };
-    if (mod && typeof mod === 'object' && 'default' in mod)
-      return { LRUCache: mod.default };
-    return mod;
-  }
-  return originalLoad(request, parent, isMain);
-};
+applyLruCacheShim();
 
 async function setupDom(html = '') {
   const { JSDOM } = await import('jsdom');

--- a/src/nav.test.js
+++ b/src/nav.test.js
@@ -1,18 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import Module from 'module';
+import { applyLruCacheShim } from './test-helpers/lru-cache-shim.js';
 
-// Shim lru-cache for jsdom on Node 22
-const originalLoad = Module._load;
-Module._load = function (request, parent, isMain) {
-  if (request === 'lru-cache') {
-    const mod = originalLoad(request, parent, isMain);
-    if (mod && typeof mod === 'function') return { LRUCache: mod };
-    if (mod && typeof mod === 'object' && 'default' in mod) return { LRUCache: mod.default };
-    return mod;
-  }
-  return originalLoad(request, parent, isMain);
-};
+applyLruCacheShim();
 
 const require = Module.createRequire(import.meta.url);
 const { JSDOM } = require('jsdom');

--- a/src/test-helpers/lru-cache-shim.js
+++ b/src/test-helpers/lru-cache-shim.js
@@ -1,0 +1,19 @@
+import Module from 'module';
+
+export function applyLruCacheShim() {
+  if (Module._load.__lruCacheShim) return;
+  const originalLoad = Module._load;
+  function shimmedLoad(request, parent, isMain) {
+    if (request === 'lru-cache') {
+      const mod = originalLoad(request, parent, isMain);
+      if (mod && typeof mod === 'function') return { LRUCache: mod };
+      if (mod && typeof mod === 'object' && 'default' in mod) {
+        return { LRUCache: mod.default };
+      }
+      return mod;
+    }
+    return originalLoad(request, parent, isMain);
+  }
+  shimmedLoad.__lruCacheShim = true;
+  Module._load = shimmedLoad;
+}


### PR DESCRIPTION
## Summary
- add helper to shim lru-cache's ESM export for jsdom
- refactor animation, fancy-title, and nav tests to use shared shim

## Testing
- `npm test`
- `TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm --test src/fancy-title.test.js src/nav.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8185144088327b1688bdf62949915