### PR TITLE
Run JS and TS tests with Hardhat

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ npm run build:web
 
 This command outputs `bundle.js` from `src/index.ts`, and the static site loads that file.
 
+## Testing
+
+Run contract and frontend tests together:
+
+```bash
+npm test
+```
+
+This runs the Hardhat suite for smart contracts and then executes all frontend tests in `src/*.test.{js,ts}` using Node's test runner.
+
+To run only the frontend tests:
+
+```bash
+npm run test:frontend
+```
+
+Both scripts support JavaScript and TypeScript test files.
+
 ## Local Development
 
 1. Clone the repository and change into the project directory:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "compile": "npx hardhat compile",
     "pretest": "node scripts/offline-compile.js",
-    "test": "npx hardhat test --no-compile && TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm --test src/animations.test.js",
+    "test": "npx hardhat test --no-compile && TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm --test src/*.test.js src/*.test.ts",
     "deploy": "npx hardhat run scripts/deploy.js --network hardhat",
     "multi-deploy": "node scripts/multichain-deploy.js",
     "lint": "eslint .",
@@ -20,7 +20,7 @@
     "dev": "npm run dev:backend & npm run dev:frontend",
     "serve": "npm run serve --workspace frontend",
     "build:web": "esbuild src/index.ts --bundle --format=esm --outfile=bundle.js",
-    "test:frontend": "TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm --test src/*.test.ts"
+    "test:frontend": "TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm --test src/*.test.js src/*.test.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- Run Hardhat tests followed by all frontend JS and TS tests
- Cover JS and TS files in `test:frontend` script
- Document new testing workflow in README

## Testing
- `npm test`
- `npm run test:frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a830ee01308327be2b0bfddbb8fca1