### PR TITLE
Guard animations when window is missing

### DIFF
--- a/src/animations.ts
+++ b/src/animations.ts
@@ -13,7 +13,14 @@ if (
   hasGSAP = true;
 }
 
-const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+const reduceMotionQuery =
+  typeof window !== 'undefined' && window.matchMedia
+    ? window.matchMedia('(prefers-reduced-motion: reduce)')
+    : ({
+        matches: false,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      } as MediaQueryList);
 export let prefersReducedMotion = reduceMotionQuery.matches;
 
 function applyAnimations() {


### PR DESCRIPTION
## Summary
- safely create `reduceMotionQuery` only when `window` exists and provide no-op fallbacks

## Testing
- `npm test`
- `npm run lint` *(fails: 'owner' is assigned a value but never used in test/StakingPool.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ad12f8acfc8327a4d8da229d95bdba