### PR TITLE
feat: add theme switch translation

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -17,7 +17,11 @@ function Navbar() {
 
   const handleTheme = () => {
     toggleTheme()
-    showNotice(`Switched to ${theme === 'dark' ? 'light' : 'dark'} mode`)
+    showNotice(
+      t('theme_switched', {
+        mode: theme === 'dark' ? t('light') : t('dark'),
+      })
+    )
   }
 
   return (

--- a/frontend/src/components/__tests__/Navbar.test.tsx
+++ b/frontend/src/components/__tests__/Navbar.test.tsx
@@ -23,7 +23,10 @@ vi.mock('../LanguageProvider', () => ({
 }))
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string, opts?: { mode?: string }) =>
+      key === 'theme_switched' ? `Switched to ${opts?.mode} mode` : key,
+  }),
   Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
 }))
 

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -106,5 +106,8 @@
   "metaverse_buy": "شراء سيف افتراضي",
   "notice_load_fail": "فشل تحميل الترجمة.",
   "notice_lang_unavailable": "اللغة المختارة غير متاحة. سيتم استخدام اللغة الافتراضية.",
-  "notice_whitepaper_unavailable": "الورقة البيضاء غير متاحة."
+  "notice_whitepaper_unavailable": "الورقة البيضاء غير متاحة.",
+  "light": "فاتح",
+  "dark": "داكن",
+  "theme_switched": "تم التبديل إلى وضع {{mode}}"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -106,5 +106,8 @@
   "metaverse_buy": "Virtuelles Schwert kaufen",
   "notice_load_fail": "Lokalisierung konnte nicht geladen werden.",
   "notice_lang_unavailable": "Ausgewählte Sprache nicht verfügbar. Standardsprache wird verwendet.",
-  "notice_whitepaper_unavailable": "Whitepaper nicht verfügbar."
+  "notice_whitepaper_unavailable": "Whitepaper nicht verfügbar.",
+  "light": "Hell",
+  "dark": "Dunkel",
+  "theme_switched": "Zum {{mode}}-Modus gewechselt"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -106,5 +106,8 @@
   "metaverse_buy": "Buy Virtual Sword",
   "notice_load_fail": "Localization failed to load.",
   "notice_lang_unavailable": "Selected language unavailable. Using default language.",
-  "notice_whitepaper_unavailable": "Whitepaper not available."
+  "notice_whitepaper_unavailable": "Whitepaper not available.",
+  "light": "Light",
+  "dark": "Dark",
+  "theme_switched": "Switched to {{mode}} mode"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -106,5 +106,8 @@
   "metaverse_buy": "Comprar Espada Virtual",
   "notice_load_fail": "No se pudo cargar la localización.",
   "notice_lang_unavailable": "El idioma seleccionado no está disponible. Se usará el idioma predeterminado.",
-  "notice_whitepaper_unavailable": "Libro blanco no disponible."
+  "notice_whitepaper_unavailable": "Libro blanco no disponible.",
+  "light": "Claro",
+  "dark": "Oscuro",
+  "theme_switched": "Se cambió al modo {{mode}}"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -106,5 +106,8 @@
   "metaverse_buy": "Acheter une Épée Virtuelle",
   "notice_load_fail": "Échec du chargement de la localisation.",
   "notice_lang_unavailable": "Langue sélectionnée indisponible. Utilisation de la langue par défaut.",
-  "notice_whitepaper_unavailable": "Livre blanc non disponible."
+  "notice_whitepaper_unavailable": "Livre blanc non disponible.",
+  "light": "Clair",
+  "dark": "Sombre",
+  "theme_switched": "Passé en mode {{mode}}"
 }

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -106,5 +106,8 @@
   "metaverse_buy": "वर्चुअल तलवार खरीदें",
   "notice_load_fail": "स्थानीयकरण लोड करने में विफल।",
   "notice_lang_unavailable": "चयनित भाषा उपलब्ध नहीं है। डिफ़ॉल्ट भाषा का उपयोग किया जाएगा।",
-  "notice_whitepaper_unavailable": "श्वेतपत्र उपलब्ध नहीं है।"
+  "notice_whitepaper_unavailable": "श्वेतपत्र उपलब्ध नहीं है।",
+  "light": "हल्का",
+  "dark": "गहरा",
+  "theme_switched": "{{mode}} मोड में बदला गया"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -106,5 +106,8 @@
   "metaverse_buy": "バーチャルソードを購入",
   "notice_load_fail": "ローカライゼーションの読み込みに失敗しました。",
   "notice_lang_unavailable": "選択した言語は利用できません。デフォルトの言語を使用します。",
-  "notice_whitepaper_unavailable": "ホワイトペーパーは利用できません。"
+  "notice_whitepaper_unavailable": "ホワイトペーパーは利用できません。",
+  "light": "ライト",
+  "dark": "ダーク",
+  "theme_switched": "{{mode}}モードに切り替えました"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -106,5 +106,8 @@
   "metaverse_buy": "가상 검 구매",
   "notice_load_fail": "로컬라이제이션을 불러오지 못했습니다.",
   "notice_lang_unavailable": "선택한 언어를 사용할 수 없습니다. 기본 언어로 표시됩니다.",
-  "notice_whitepaper_unavailable": "백서를 사용할 수 없습니다."
+  "notice_whitepaper_unavailable": "백서를 사용할 수 없습니다.",
+  "light": "라이트",
+  "dark": "다크",
+  "theme_switched": "{{mode}} 모드로 전환되었습니다"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -106,5 +106,8 @@
   "metaverse_buy": "Comprar Espada Virtual",
   "notice_load_fail": "Falha ao carregar a localização.",
   "notice_lang_unavailable": "Idioma selecionado indisponível. Usando o idioma padrão.",
-  "notice_whitepaper_unavailable": "Whitepaper indisponível."
+  "notice_whitepaper_unavailable": "Whitepaper indisponível.",
+  "light": "Claro",
+  "dark": "Escuro",
+  "theme_switched": "Mudou para o modo {{mode}}"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -106,5 +106,8 @@
   "metaverse_buy": "Купить виртуальный меч",
   "notice_load_fail": "Не удалось загрузить локализацию.",
   "notice_lang_unavailable": "Выбранный язык недоступен. Используется язык по умолчанию.",
-  "notice_whitepaper_unavailable": "Whitepaper недоступен."
+  "notice_whitepaper_unavailable": "Whitepaper недоступен.",
+  "light": "Светлый",
+  "dark": "Тёмный",
+  "theme_switched": "Переключено в {{mode}} режим"
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -106,5 +106,8 @@
   "metaverse_buy": "购买虚拟之剑",
   "notice_load_fail": "加载本地化失败。",
   "notice_lang_unavailable": "所选语言不可用，已使用默认语言。",
-  "notice_whitepaper_unavailable": "白皮书不可用。"
+  "notice_whitepaper_unavailable": "白皮书不可用。",
+  "light": "浅色",
+  "dark": "深色",
+  "theme_switched": "已切换到{{mode}}模式"
 }


### PR DESCRIPTION
## Summary
- add `theme_switched`, `light`, and `dark` keys to all locales
- use translated theme switch notice in navbar
- update navbar test to mock new translation behavior

## Testing
- `npm run check-locales`
- `npm test`
- `npm run test --workspace frontend -- --run`
- `npm run lint` *(fails: Definition for rule 'unicorn/prefer-includes' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4dc8f1a083278a900e59834c86cf