### PR TITLE
fix: link navbar logo to root

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -26,7 +26,7 @@ function Navbar() {
 
   return (
     <nav className={styles.navbar} ref={navRef}>
-      <a href="index.html" className={styles.logo}>
+      <a href="/" className={styles.logo}>
         <img src="/assets/hall-symbol.svg" alt="HALL logo" width="24" height="24" />
         Hallyu Chain
       </a>


### PR DESCRIPTION
## Summary
- point navbar logo to site root instead of index.html

## Testing
- `CI=1 npm test --workspace frontend`
- `npm run lint --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_68ad551f392883278af2aa2a1cb188d5