### PR TITLE
Normalize tokenomics distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ RPC URLs and the deployer's private key are read from environment variables (`SE
 ## Tokenomics
 
 - Total supply: 10,000,000,000 HALL
-- DAO treasury: 50%
-- Community rewards: 20%
-- Team: 15%
-- Advisors: 5%
-- Investors: 10%
-- Transfer burn: 3%
+- DAO treasury: 48.54%
+- Community rewards: 19.42%
+- Team: 14.56%
+- Advisors: 4.86%
+- Investors: 9.71%
+- Transfer burn: 2.91%
 
 ## Roadmap
 

--- a/frontend/src/components/__tests__/Tokenomics.test.tsx
+++ b/frontend/src/components/__tests__/Tokenomics.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import Tokenomics from '../Tokenomics'
+import tok from '../../../../tokenomics.json'
 
 vi.mock('gsap', () => ({
   default: {
@@ -25,10 +26,17 @@ vi.mock('react-i18next', () => ({
 }))
 
 describe('Tokenomics', () => {
-  it('renders heading and list items', () => {
+  it('renders tokenomics values', () => {
     render(<Tokenomics />)
     expect(screen.getByText('tokenomics_title')).toBeInTheDocument()
     const items = screen.getAllByRole('listitem')
     expect(items).toHaveLength(7)
+    expect(screen.getByText(`tok_list1 ${tok.supply}`)).toBeInTheDocument()
+    expect(screen.getByText(`tok_list2 ${tok.dao}`)).toBeInTheDocument()
+    expect(screen.getByText(`tok_list3 ${tok.community}`)).toBeInTheDocument()
+    expect(screen.getByText(`tok_list4 ${tok.team}`)).toBeInTheDocument()
+    expect(screen.getByText(`tok_list5 ${tok.advisors}`)).toBeInTheDocument()
+    expect(screen.getByText(`tok_list6 ${tok.investors}`)).toBeInTheDocument()
+    expect(screen.getByText(`tok_list7 ${tok.burn}`)).toBeInTheDocument()
   })
 })

--- a/tokenomics.json
+++ b/tokenomics.json
@@ -1,9 +1,9 @@
 {
   "supply": 10000000000,
-  "dao": 50,
-  "community": 20,
-  "team": 15,
-  "advisors": 5,
-  "investors": 10,
-  "burn": 3
+  "dao": 48.54,
+  "community": 19.42,
+  "team": 14.56,
+  "advisors": 4.86,
+  "investors": 9.71,
+  "burn": 2.91
 }


### PR DESCRIPTION
## Summary
- scale token allocation percentages so their sum equals 100%
- document updated tokenomics figures in README
- test frontend tokenomics component renders current values

## Testing
- `npm test`
- `CI=1 npm test --workspace frontend`
- `npm run lint` *(fails: Unnecessary escape character: \-)*

------
https://chatgpt.com/codex/tasks/task_e_68ad633d0c748327b8584d02c6b85bce