### PR TITLE
feat: add K-pop hero background

### DIFF
--- a/assets/kpop-bg.svg
+++ b/assets/kpop-bg.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff4b91" />
+      <stop offset="100%" stop-color="#7c4dff" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#grad)" />
+  <text x="50%" y="50%" text-anchor="middle" font-size="160" fill="#ffffff55" font-family="Montserrat, sans-serif">K-POP</text>
+  <g fill="#ffffff33">
+    <circle cx="200" cy="200" r="60" />
+    <circle cx="1000" cy="400" r="80" />
+    <circle cx="600" cy="700" r="50" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -181,6 +181,11 @@
     </nav>
 
     <header class="hero">
+      <img
+        class="hero-media"
+        src="assets/kpop-bg.svg"
+        alt="Abstract K-POP themed background"
+      />
       <hc-fancy-title
         class="hero-title"
         text="Hallyu Chain"

--- a/style.css
+++ b/style.css
@@ -183,6 +183,17 @@ body {
   position: relative;
   overflow: hidden;
   perspective: 800px;
+  background-color: #000;
+}
+
+.hero-media {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: -2;
 }
 
 .hero::before {
@@ -197,12 +208,19 @@ body {
   animation: heroGradient 15s ease infinite;
   z-index: -1;
   filter: blur(var(--hero-blur));
+  opacity: 0.6;
 }
 
 @keyframes heroGradient {
   0% { background-position: 0% 50%; }
   50% { background-position: 100% 50%; }
   100% { background-position: 0% 50%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero::before {
+    animation: none;
+  }
 }
 
 .hero h1 {


### PR DESCRIPTION
## Summary
- add K-POP themed background image to hero block with alt text
- style hero media with responsive cover, blur overlay, fallback color, and reduced-motion support

## Testing
- `npm test`
- `npm run lint` *(fails: Definition for rule 'unicorn/prefer-includes' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad69fb15508327b21d6b86e7ad1958