### PR TITLE
Use theme variable for navbar background

### DIFF
--- a/style.css
+++ b/style.css
@@ -89,7 +89,7 @@ body {
   justify-content: space-between;
   align-items: center;
   padding: var(--space-sm) var(--space-lg);
-  background: rgba(255,255,255,0.8);
+  background: var(--surface);
   backdrop-filter: blur(5px);
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   z-index: 10;


### PR DESCRIPTION
## Summary
- switch navbar to use `var(--surface)` so the background follows light/dark themes

## Testing
- `npm test`
- `npm run lint` *(fails: Definition for rule 'unicorn/prefer-includes' was not found, plus unused vars)*
- `npx playwright screenshot "file://$(pwd)/index.html" light.png`
- `npx playwright screenshot --color-scheme=dark "file://$(pwd)/index.html" dark.png`
- `python3 - <<'PY'
from PIL import Image
for mode in ['light.png','dark.png']:
    img=Image.open(mode)
    pixel=img.getpixel((10,10))
    print(mode, pixel)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ae89c7e19c83279e2a60392d396c20