### PR TITLE
Mark material icons decorative and drop redundant loop

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1146,6 +1146,13 @@ async function setLanguage(lang) {
       el.setAttribute("placeholder", text2);
     }
   });
+  document.querySelectorAll("[data-i18n-alt]").forEach((el) => {
+    const key = el.getAttribute("data-i18n-alt");
+    const text2 = translations[lang][key];
+    if (text2) {
+      el.setAttribute("alt", text2);
+    }
+  });
   document.querySelectorAll("[data-i18n-aria-label]").forEach((el) => {
     const key = el.getAttribute("data-i18n-aria-label");
     const text2 = translations[lang][key];
@@ -1439,7 +1446,6 @@ function initAnimations() {
 }
 
 // src/index.ts
-document.querySelectorAll(".material-symbols-outlined").forEach((icon) => icon.setAttribute("aria-hidden", "true"));
 applyFancyTitles();
 initNav();
 initAnimations();

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -37,7 +37,7 @@ function Navbar() {
         aria-expanded={open}
         onClick={() => setOpen((o) => !o)}
       >
-        <i className="material-symbols-outlined">menu</i>
+        <i className="material-symbols-outlined" aria-hidden="true">menu</i>
       </button>
       <ul
         className={`${styles.navLinks} ${open ? styles.navLinksOpen : ''}`}
@@ -45,7 +45,7 @@ function Navbar() {
       >
         <li>
           <a href="#about">
-            <i className="material-symbols-outlined">info</i>
+            <i className="material-symbols-outlined" aria-hidden="true">info</i>
             <span>
               <Trans i18nKey="nav_about" />
             </span>
@@ -53,7 +53,7 @@ function Navbar() {
         </li>
         <li>
           <a href="#technology">
-            <i className="material-symbols-outlined">memory</i>
+            <i className="material-symbols-outlined" aria-hidden="true">memory</i>
             <span>
               <Trans i18nKey="nav_technology" />
             </span>
@@ -61,7 +61,7 @@ function Navbar() {
         </li>
         <li>
           <a href="#tokenomics">
-            <i className="material-symbols-outlined">paid</i>
+            <i className="material-symbols-outlined" aria-hidden="true">paid</i>
             <span>
               <Trans i18nKey="nav_tokenomics" />
             </span>
@@ -69,7 +69,7 @@ function Navbar() {
         </li>
         <li>
           <a href="#roadmap">
-            <i className="material-symbols-outlined">map</i>
+            <i className="material-symbols-outlined" aria-hidden="true">map</i>
             <span>
               <Trans i18nKey="nav_roadmap" />
             </span>
@@ -77,7 +77,7 @@ function Navbar() {
         </li>
         <li>
           <a href="#dao">
-            <i className="material-symbols-outlined">groups</i>
+            <i className="material-symbols-outlined" aria-hidden="true">groups</i>
             <span>
               <Trans i18nKey="nav_dao" />
             </span>
@@ -85,7 +85,7 @@ function Navbar() {
         </li>
         <li>
           <a href="#partners">
-            <i className="material-symbols-outlined">handshake</i>
+            <i className="material-symbols-outlined" aria-hidden="true">handshake</i>
             <span>
               <Trans i18nKey="nav_partners" />
             </span>
@@ -93,7 +93,7 @@ function Navbar() {
         </li>
         <li>
           <a href="#resources">
-            <i className="material-symbols-outlined">menu_book</i>
+            <i className="material-symbols-outlined" aria-hidden="true">menu_book</i>
             <span>
               <Trans i18nKey="nav_resources" />
             </span>
@@ -101,7 +101,7 @@ function Navbar() {
         </li>
         <li>
           <a href="#newsletter">
-            <i className="material-symbols-outlined">mail</i>
+            <i className="material-symbols-outlined" aria-hidden="true">mail</i>
             <span>
               <Trans i18nKey="nav_newsletter" />
             </span>
@@ -109,7 +109,7 @@ function Navbar() {
         </li>
         <li>
           <a href="#faq">
-            <i className="material-symbols-outlined">help</i>
+            <i className="material-symbols-outlined" aria-hidden="true">help</i>
             <span>
               <Trans i18nKey="nav_faq" />
             </span>
@@ -117,7 +117,7 @@ function Navbar() {
         </li>
         <li>
           <a href="#corporate">
-            <i className="material-symbols-outlined">apartment</i>
+            <i className="material-symbols-outlined" aria-hidden="true">apartment</i>
             <span>
               <Trans i18nKey="nav_corporate" />
             </span>
@@ -125,7 +125,7 @@ function Navbar() {
         </li>
         <li>
           <a href="#team">
-            <i className="material-symbols-outlined">group</i>
+            <i className="material-symbols-outlined" aria-hidden="true">group</i>
             <span>
               <Trans i18nKey="nav_team" />
             </span>
@@ -133,7 +133,7 @@ function Navbar() {
         </li>
         <li>
           <a href="#whitepaper">
-            <i className="material-symbols-outlined">description</i>
+            <i className="material-symbols-outlined" aria-hidden="true">description</i>
             <span>
               <Trans i18nKey="nav_whitepaper" />
             </span>
@@ -145,7 +145,7 @@ function Navbar() {
         aria-label={t('nav_theme')}
         onClick={handleTheme}
       >
-        <i className="material-symbols-outlined">
+        <i className="material-symbols-outlined" aria-hidden="true">
           {theme === 'dark' ? 'light_mode' : 'dark_mode'}
         </i>
       </button>

--- a/frontend/src/components/Partners.tsx
+++ b/frontend/src/components/Partners.tsx
@@ -8,19 +8,19 @@ function Partners() {
       </h2>
       <div className="logo-grid">
         <div className="logo-item">
-          <i className="material-symbols-outlined">music_note</i>
+          <i className="material-symbols-outlined" aria-hidden="true">music_note</i>
           <span>
             <Trans i18nKey="partner1" />
           </span>
         </div>
         <div className="logo-item">
-          <i className="material-symbols-outlined">sports_esports</i>
+          <i className="material-symbols-outlined" aria-hidden="true">sports_esports</i>
           <span>
             <Trans i18nKey="partner2" />
           </span>
         </div>
         <div className="logo-item">
-          <i className="material-symbols-outlined">movie</i>
+          <i className="material-symbols-outlined" aria-hidden="true">movie</i>
           <span>
             <Trans i18nKey="partner3" />
           </span>

--- a/frontend/src/components/Resources.tsx
+++ b/frontend/src/components/Resources.tsx
@@ -8,13 +8,13 @@ function Resources() {
       </h2>
       <ul className="icon-list">
         <li>
-          <i className="material-symbols-outlined">insert_drive_file</i>
+          <i className="material-symbols-outlined" aria-hidden="true">insert_drive_file</i>
           <a href="#whitepaper">
             <Trans i18nKey="res_whitepaper" />
           </a>
         </li>
         <li>
-          <i className="material-symbols-outlined">code</i>
+          <i className="material-symbols-outlined" aria-hidden="true">code</i>
           <a
             href="https://github.com/hallyu-chain"
             target="_blank"
@@ -24,7 +24,7 @@ function Resources() {
           </a>
         </li>
         <li>
-          <i className="material-symbols-outlined">chat</i>
+          <i className="material-symbols-outlined" aria-hidden="true">chat</i>
           <a
             href="https://discord.gg/example"
             target="_blank"

--- a/frontend/src/components/Roadmap.tsx
+++ b/frontend/src/components/Roadmap.tsx
@@ -8,49 +8,49 @@ function Roadmap() {
       </h2>
       <ol className="icon-list">
         <li>
-          <i className="material-symbols-outlined">rocket_launch</i>
+          <i className="material-symbols-outlined" aria-hidden="true">rocket_launch</i>
           <span>
             <Trans i18nKey="road_q1" />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">code</i>
+          <i className="material-symbols-outlined" aria-hidden="true">code</i>
           <span>
             <Trans i18nKey="road_q2" />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">handshake</i>
+          <i className="material-symbols-outlined" aria-hidden="true">handshake</i>
           <span>
             <Trans i18nKey="road_q3" />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">link</i>
+          <i className="material-symbols-outlined" aria-hidden="true">link</i>
           <span>
             <Trans i18nKey="road_q4" />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">storefront</i>
+          <i className="material-symbols-outlined" aria-hidden="true">storefront</i>
           <span>
             <Trans i18nKey="road_q5" />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">smartphone</i>
+          <i className="material-symbols-outlined" aria-hidden="true">smartphone</i>
           <span>
             <Trans i18nKey="road_q6" />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">savings</i>
+          <i className="material-symbols-outlined" aria-hidden="true">savings</i>
           <span>
             <Trans i18nKey="road_q7" />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">how_to_vote</i>
+          <i className="material-symbols-outlined" aria-hidden="true">how_to_vote</i>
           <span>
             <Trans i18nKey="road_q8" />
           </span>

--- a/frontend/src/components/Team.tsx
+++ b/frontend/src/components/Team.tsx
@@ -25,7 +25,7 @@ function Team() {
       </h3>
       <ul className="icon-list">
         <li>
-          <i className="material-symbols-outlined">public</i>
+          <i className="material-symbols-outlined" aria-hidden="true">public</i>
           <a
             href="https://twitter.com/hallyu_chain"
             target="_blank"
@@ -35,7 +35,7 @@ function Team() {
           </a>
         </li>
         <li>
-          <i className="material-symbols-outlined">chat</i>
+          <i className="material-symbols-outlined" aria-hidden="true">chat</i>
           <a
             href="https://discord.gg/example"
             target="_blank"
@@ -45,7 +45,7 @@ function Team() {
           </a>
         </li>
         <li>
-          <i className="material-symbols-outlined">code</i>
+          <i className="material-symbols-outlined" aria-hidden="true">code</i>
           <a
             href="https://github.com/hallyu-chain"
             target="_blank"

--- a/frontend/src/components/Technology.tsx
+++ b/frontend/src/components/Technology.tsx
@@ -8,25 +8,25 @@ function Technology() {
       </h2>
       <ul className="icon-list">
         <li>
-          <i className="material-symbols-outlined">layers</i>
+          <i className="material-symbols-outlined" aria-hidden="true">layers</i>
           <span>
             <Trans i18nKey="tech_list1" />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">gavel</i>
+          <i className="material-symbols-outlined" aria-hidden="true">gavel</i>
           <span>
             <Trans i18nKey="tech_list2" />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">shield</i>
+          <i className="material-symbols-outlined" aria-hidden="true">shield</i>
           <span>
             <Trans i18nKey="tech_list3" />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">compare_arrows</i>
+          <i className="material-symbols-outlined" aria-hidden="true">compare_arrows</i>
           <span>
             <Trans i18nKey="tech_list4" />
           </span>
@@ -37,7 +37,7 @@ function Technology() {
       </h2>
       <div className="card-grid">
         <div className="card">
-          <i className="material-symbols-outlined">group</i>
+          <i className="material-symbols-outlined" aria-hidden="true">group</i>
           <h3>
             <Trans i18nKey="feat1_title" />
           </h3>
@@ -46,7 +46,7 @@ function Technology() {
           </p>
         </div>
         <div className="card">
-          <i className="material-symbols-outlined">volunteer_activism</i>
+          <i className="material-symbols-outlined" aria-hidden="true">volunteer_activism</i>
           <h3>
             <Trans i18nKey="feat2_title" />
           </h3>
@@ -55,7 +55,7 @@ function Technology() {
           </p>
         </div>
         <div className="card">
-          <i className="material-symbols-outlined">public</i>
+          <i className="material-symbols-outlined" aria-hidden="true">public</i>
           <h3>
             <Trans i18nKey="feat3_title" />
           </h3>
@@ -64,7 +64,7 @@ function Technology() {
           </p>
         </div>
         <div className="card">
-          <i className="material-symbols-outlined">token</i>
+          <i className="material-symbols-outlined" aria-hidden="true">token</i>
           <h3>
             <Trans i18nKey="feat4_title" />
           </h3>

--- a/frontend/src/components/Tokenomics.tsx
+++ b/frontend/src/components/Tokenomics.tsx
@@ -33,43 +33,43 @@ function Tokenomics() {
       </h2>
       <ul className={styles.iconList}>
         <li>
-          <i className="material-symbols-outlined">pie_chart</i>
+          <i className="material-symbols-outlined" aria-hidden="true">pie_chart</i>
           <span>
             <Trans i18nKey="tok_list1" values={{ supply: tok.supply }} />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">account_balance</i>
+          <i className="material-symbols-outlined" aria-hidden="true">account_balance</i>
           <span>
             <Trans i18nKey="tok_list2" values={{ dao: tok.dao }} />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">card_giftcard</i>
+          <i className="material-symbols-outlined" aria-hidden="true">card_giftcard</i>
           <span>
             <Trans i18nKey="tok_list3" values={{ community: tok.community }} />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">groups</i>
+          <i className="material-symbols-outlined" aria-hidden="true">groups</i>
           <span>
             <Trans i18nKey="tok_list4" values={{ team: tok.team }} />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">support_agent</i>
+          <i className="material-symbols-outlined" aria-hidden="true">support_agent</i>
           <span>
             <Trans i18nKey="tok_list5" values={{ advisors: tok.advisors }} />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">trending_up</i>
+          <i className="material-symbols-outlined" aria-hidden="true">trending_up</i>
           <span>
             <Trans i18nKey="tok_list6" values={{ investors: tok.investors }} />
           </span>
         </li>
         <li>
-          <i className="material-symbols-outlined">local_fire_department</i>
+          <i className="material-symbols-outlined" aria-hidden="true">local_fire_department</i>
           <span>
             <Trans i18nKey="tok_list7" values={{ burn: tok.burn }} />
           </span>

--- a/index.html
+++ b/index.html
@@ -86,78 +86,78 @@
         aria-controls="primary-navigation"
         aria-expanded="false"
       >
-        <i class="material-symbols-outlined">menu</i>
+        <i class="material-symbols-outlined" aria-hidden="true">menu</i>
       </button>
       <ul class="nav-links" id="primary-navigation">
         <li>
           <a href="#about"
-            ><i class="material-symbols-outlined">info</i
+            ><i class="material-symbols-outlined" aria-hidden="true">info</i
             ><span data-i18n="nav_about">소개</span></a
           >
         </li>
         <li>
           <a href="#technology"
-            ><i class="material-symbols-outlined">memory</i
+            ><i class="material-symbols-outlined" aria-hidden="true">memory</i
             ><span data-i18n="nav_technology">기술</span></a
           >
         </li>
         <li>
           <a href="#tokenomics"
-            ><i class="material-symbols-outlined">paid</i
+            ><i class="material-symbols-outlined" aria-hidden="true">paid</i
             ><span data-i18n="nav_tokenomics">토큰 이코노미</span></a
           >
         </li>
         <li>
           <a href="#roadmap"
-            ><i class="material-symbols-outlined">map</i
+            ><i class="material-symbols-outlined" aria-hidden="true">map</i
             ><span data-i18n="nav_roadmap">로드맵</span></a
           >
         </li>
         <li>
           <a href="#dao"
-            ><i class="material-symbols-outlined">groups</i
+            ><i class="material-symbols-outlined" aria-hidden="true">groups</i
             ><span data-i18n="nav_dao">DAO</span></a
           >
         </li>
         <li>
           <a href="#partners"
-            ><i class="material-symbols-outlined">handshake</i
+            ><i class="material-symbols-outlined" aria-hidden="true">handshake</i
             ><span data-i18n="nav_partners">파트너</span></a
           >
         </li>
         <li>
           <a href="#resources"
-            ><i class="material-symbols-outlined">menu_book</i
+            ><i class="material-symbols-outlined" aria-hidden="true">menu_book</i
             ><span data-i18n="nav_resources">참고 자료</span></a
           >
         </li>
         <li>
           <a href="#newsletter"
-            ><i class="material-symbols-outlined">mail</i
+            ><i class="material-symbols-outlined" aria-hidden="true">mail</i
             ><span data-i18n="nav_newsletter">뉴스레터</span></a
           >
         </li>
         <li>
           <a href="#faq"
-            ><i class="material-symbols-outlined">help</i
+            ><i class="material-symbols-outlined" aria-hidden="true">help</i
             ><span data-i18n="nav_faq">FAQ</span></a
           >
         </li>
         <li>
           <a href="#corporate"
-            ><i class="material-symbols-outlined">apartment</i
+            ><i class="material-symbols-outlined" aria-hidden="true">apartment</i
             ><span data-i18n="nav_corporate">기업 아이덴티티</span></a
           >
         </li>
         <li>
           <a href="#team"
-            ><i class="material-symbols-outlined">group</i
+            ><i class="material-symbols-outlined" aria-hidden="true">group</i
             ><span data-i18n="nav_team">팀</span></a
           >
         </li>
         <li>
           <a href="#whitepaper"
-            ><i class="material-symbols-outlined">description</i
+            ><i class="material-symbols-outlined" aria-hidden="true">description</i
             ><span data-i18n="nav_whitepaper">백서</span></a
           >
         </li>
@@ -167,7 +167,7 @@
         aria-label="테마 전환"
         data-i18n-aria-label="nav_theme"
       >
-        <i class="material-symbols-outlined">dark_mode</i>
+        <i class="material-symbols-outlined" aria-hidden="true">dark_mode</i>
       </button>
       <select class="lang-select" data-i18n-aria-label="nav_change_lang">
         <option value="ko">🇰🇷</option>
@@ -211,17 +211,17 @@
       </p>
       <ul class="icon-list">
         <li>
-          <i class="material-symbols-outlined">how_to_vote</i
+          <i class="material-symbols-outlined" aria-hidden="true">how_to_vote</i
           ><span data-i18n="about_benefit1">독점 콘텐츠와 이벤트에 투표</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">handshake</i
+          <i class="material-symbols-outlined" aria-hidden="true">handshake</i
           ><span data-i18n="about_benefit2"
             >토큰 기반 경험으로 아티스트와 직접 소통</span
           >
         </li>
         <li>
-          <i class="material-symbols-outlined">redeem</i
+          <i class="material-symbols-outlined" aria-hidden="true">redeem</i
           ><span data-i18n="about_benefit3">한정판 굿즈와 리워드 획득</span>
         </li>
       </ul>
@@ -269,19 +269,19 @@
       <h2 data-i18n="technology_title">핵심 기술</h2>
       <ul class="icon-list">
         <li>
-          <i class="material-symbols-outlined">layers</i
+          <i class="material-symbols-outlined" aria-hidden="true">layers</i
           ><span data-i18n="tech_list1">하이브리드 PoS/DPoS 합의 알고리즘</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">gavel</i
+          <i class="material-symbols-outlined" aria-hidden="true">gavel</i
           ><span data-i18n="tech_list2">스마트 컨트랙트 기반 팬 서비스</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">shield</i
+          <i class="material-symbols-outlined" aria-hidden="true">shield</i
           ><span data-i18n="tech_list3">양자 내성 암호화 기법</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">compare_arrows</i
+          <i class="material-symbols-outlined" aria-hidden="true">compare_arrows</i
           ><span data-i18n="tech_list4">Cross-chain Bridge with fee burn</span>
         </li>
       </ul>
@@ -291,28 +291,28 @@
       <h2 data-i18n="features_title">주요 기능</h2>
       <div class="card-grid">
         <div class="card">
-          <i class="material-symbols-outlined">group</i>
+          <i class="material-symbols-outlined" aria-hidden="true">group</i>
           <h3 data-i18n="feat1_title">팬 참여</h3>
           <p data-i18n="feat1_text">
             팬이 직접 프로젝트에 참여하고 의견을 제시할 수 있는 플랫폼
           </p>
         </div>
         <div class="card">
-          <i class="material-symbols-outlined">volunteer_activism</i>
+          <i class="material-symbols-outlined" aria-hidden="true">volunteer_activism</i>
           <h3 data-i18n="feat2_title">아티스트 지원</h3>
           <p data-i18n="feat2_text">
             팬이 좋아하는 아티스트를 직접 후원할 수 있는 투명한 시스템
           </p>
         </div>
         <div class="card">
-          <i class="material-symbols-outlined">public</i>
+          <i class="material-symbols-outlined" aria-hidden="true">public</i>
           <h3 data-i18n="feat3_title">글로벌 커뮤니티</h3>
           <p data-i18n="feat3_text">
             언어와 국경을 초월한 글로벌 팬 커뮤니티 형성
           </p>
         </div>
         <div class="card">
-          <i class="material-symbols-outlined">token</i>
+          <i class="material-symbols-outlined" aria-hidden="true">token</i>
           <h3 data-i18n="feat4_title">스테이킹 혜택</h3>
           <p data-i18n="feat4_text">
             토큰을 스테이킹하면 특별한 보상을 받을 수 있습니다
@@ -325,31 +325,31 @@
       <h2 data-i18n="tokenomics_title">토큰 이코노미</h2>
       <ul class="icon-list">
         <li>
-          <i class="material-symbols-outlined">pie_chart</i
+          <i class="material-symbols-outlined" aria-hidden="true">pie_chart</i
           ><span data-i18n="tok_list1">총 발행량: {supply} HALL</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">account_balance</i
+          <i class="material-symbols-outlined" aria-hidden="true">account_balance</i
           ><span data-i18n="tok_list2">DAO 재무금고: {dao}%</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">card_giftcard</i
+          <i class="material-symbols-outlined" aria-hidden="true">card_giftcard</i
           ><span data-i18n="tok_list3">커뮤니티 리워드: {community}%</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">groups</i
+          <i class="material-symbols-outlined" aria-hidden="true">groups</i
           ><span data-i18n="tok_list4">팀: {team}%</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">support_agent</i
+          <i class="material-symbols-outlined" aria-hidden="true">support_agent</i
           ><span data-i18n="tok_list5">자문단: {advisors}%</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">trending_up</i
+          <i class="material-symbols-outlined" aria-hidden="true">trending_up</i
           ><span data-i18n="tok_list6">투자자: {investors}%</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">local_fire_department</i
+          <i class="material-symbols-outlined" aria-hidden="true">local_fire_department</i
           ><span data-i18n="tok_list7">전송 소각: {burn}%</span>
         </li>
       </ul>
@@ -359,35 +359,35 @@
       <h2 data-i18n="roadmap_title">로드맵</h2>
       <ol class="icon-list">
         <li>
-          <i class="material-symbols-outlined">rocket_launch</i
+          <i class="material-symbols-outlined" aria-hidden="true">rocket_launch</i
           ><span data-i18n="road_q1">2026 Q1: 메인넷 런칭</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">code</i
+          <i class="material-symbols-outlined" aria-hidden="true">code</i
           ><span data-i18n="road_q2">2026 Q2: 스마트 컨트랙트 플랫폼 공개</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">handshake</i
+          <i class="material-symbols-outlined" aria-hidden="true">handshake</i
           ><span data-i18n="road_q3">2026 Q3: 글로벌 파트너십 확대</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">link</i
+          <i class="material-symbols-outlined" aria-hidden="true">link</i
           ><span data-i18n="road_q4">2026 Q4: 크로스체인 브리지 구현</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">storefront</i
+          <i class="material-symbols-outlined" aria-hidden="true">storefront</i
           ><span data-i18n="road_q5">2027 Q1: NFT 마켓플레이스 출시</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">smartphone</i
+          <i class="material-symbols-outlined" aria-hidden="true">smartphone</i
           ><span data-i18n="road_q6">2027 Q2: 모바일 지갑 도입</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">savings</i
+          <i class="material-symbols-outlined" aria-hidden="true">savings</i
           ><span data-i18n="road_q7">2027 Q3: 스테이킹 보상 확대</span>
         </li>
         <li>
-          <i class="material-symbols-outlined">how_to_vote</i
+          <i class="material-symbols-outlined" aria-hidden="true">how_to_vote</i
           ><span data-i18n="road_q8">2027 Q4: 온체인 거버넌스 론칭</span>
         </li>
       </ol>
@@ -404,15 +404,15 @@
       <h2 data-i18n="partners_title">파트너</h2>
       <div class="logo-grid">
         <div class="logo-item">
-          <i class="material-symbols-outlined">music_note</i
+          <i class="material-symbols-outlined" aria-hidden="true">music_note</i
           ><span data-i18n="partner1">뮤직체인</span>
         </div>
         <div class="logo-item">
-          <i class="material-symbols-outlined">sports_esports</i
+          <i class="material-symbols-outlined" aria-hidden="true">sports_esports</i
           ><span data-i18n="partner2">게임월드</span>
         </div>
         <div class="logo-item">
-          <i class="material-symbols-outlined">movie</i
+          <i class="material-symbols-outlined" aria-hidden="true">movie</i
           ><span data-i18n="partner3">엔터미디어</span>
         </div>
       </div>
@@ -422,13 +422,13 @@
       <h2 data-i18n="resources_title">참고 자료</h2>
       <ul class="icon-list">
         <li>
-          <i class="material-symbols-outlined">insert_drive_file</i
+          <i class="material-symbols-outlined" aria-hidden="true">insert_drive_file</i
           ><a href="#whitepaper"
             ><span data-i18n="res_whitepaper">백서</span></a
           >
         </li>
         <li>
-          <i class="material-symbols-outlined">code</i
+          <i class="material-symbols-outlined" aria-hidden="true">code</i
           ><a
             href="https://github.com/hallyu-chain"
             target="_blank"
@@ -437,7 +437,7 @@
           >
         </li>
         <li>
-          <i class="material-symbols-outlined">chat</i
+          <i class="material-symbols-outlined" aria-hidden="true">chat</i
           ><a
             href="https://discord.gg/example"
             target="_blank"
@@ -591,7 +591,7 @@
       <h2 data-i18n="team_links_title">팀 소셜</h2>
       <ul class="icon-list">
         <li>
-          <i class="material-symbols-outlined">public</i
+          <i class="material-symbols-outlined" aria-hidden="true">public</i
           ><a
             href="https://twitter.com/hallyu_chain"
             target="_blank"
@@ -600,7 +600,7 @@
           >
         </li>
         <li>
-          <i class="material-symbols-outlined">chat</i
+          <i class="material-symbols-outlined" aria-hidden="true">chat</i
           ><a
             href="https://discord.gg/example"
             target="_blank"
@@ -609,7 +609,7 @@
           >
         </li>
         <li>
-          <i class="material-symbols-outlined">code</i
+          <i class="material-symbols-outlined" aria-hidden="true">code</i
           ><a
             href="https://github.com/hallyu-chain"
             target="_blank"
@@ -634,7 +634,7 @@
       aria-label="맨 위로"
       data-i18n-aria-label="back_to_top"
     >
-      <i class="material-symbols-outlined">arrow_upward</i>
+      <i class="material-symbols-outlined" aria-hidden="true">arrow_upward</i>
     </button>
 
     <script type="module" src="bundle.js"></script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,6 @@ import { initNav } from './nav.ts';
 import { applyFancyTitles } from './fancy-title.ts';
 import { initAnimations, prefersReducedMotion } from './animations.ts';
 
-// Hide decorative icons from screen readers
-document
-  .querySelectorAll('.material-symbols-outlined')
-  .forEach((icon) => icon.setAttribute('aria-hidden', 'true'));
-
 applyFancyTitles();
 initNav();
 initAnimations();


### PR DESCRIPTION
## Summary
- Annotate all Material icons with `aria-hidden="true"` in index and React components so they are ignored by assistive tech
- Remove DOM loop that previously set the attribute at runtime
- Rebuild bundle to reflect the removal

## Testing
- `npm run build:web`
- `npm test`
- `npm test --workspace frontend -- --run`
- `npm run lint` *(fails: Definition for rule 'unicorn/prefer-includes' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8cd7e6848327b9334d0091bc519e