### PR TITLE
feat: darken hero background for accessibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@
   --surface: rgba(0,0,0,0.05);
   --hero-gradient: linear-gradient(-45deg,#fff1f2,#fffbeb,#e0f2fe,#f3e8ff);
   --hero-blur: 60px;
+  --hero-overlay: rgba(0,0,0,0.4);
   --nav-height: 60px;
   --space-xs: 0.5rem;
   --space-sm: 1rem;
@@ -21,6 +22,7 @@
     --surface: rgba(255,255,255,0.1);
     --hero-gradient: linear-gradient(-45deg,#4e54c8,#8f94fb,#232526,#414345);
     --hero-blur: 80px;
+    --hero-overlay: rgba(0,0,0,0.6);
   }
 }
 
@@ -40,6 +42,7 @@ body.dark-mode {
   --surface: rgba(255,255,255,0.1);
   --hero-gradient: linear-gradient(-45deg,#4e54c8,#8f94fb,#232526,#414345);
   --hero-blur: 80px;
+  --hero-overlay: rgba(0,0,0,0.6);
   color-scheme: dark;
 }
 
@@ -49,6 +52,7 @@ body.light-mode {
   --surface: rgba(0,0,0,0.05);
   --hero-gradient: linear-gradient(-45deg,#fff1f2,#fffbeb,#e0f2fe,#f3e8ff);
   --hero-blur: 60px;
+  --hero-overlay: rgba(0,0,0,0.4);
   color-scheme: light;
 }
 
@@ -184,6 +188,7 @@ body {
   overflow: hidden;
   perspective: 800px;
   background-color: #000;
+  color: var(--fg);
 }
 
 .hero-media {
@@ -203,12 +208,11 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
-  background: var(--hero-gradient);
+  background: linear-gradient(var(--hero-overlay), var(--hero-overlay)), var(--hero-gradient);
   background-size: 400% 400%;
   animation: heroGradient 15s ease infinite;
   z-index: -1;
   filter: blur(var(--hero-blur));
-  opacity: 0.6;
 }
 
 @keyframes heroGradient {


### PR DESCRIPTION
## Summary
- add theme-aware `--hero-overlay` variable
- apply dark overlay to hero gradient for better text contrast

## Testing
- `npm test`
- `npm run lint` *(fails: Definition for rule 'unicorn/prefer-includes' was not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ae8ce718ac8327829f2a0ad62412d0