### PR TITLE
feat: localize head metadata

### DIFF
--- a/frontend/src/components/Head.tsx
+++ b/frontend/src/components/Head.tsx
@@ -1,8 +1,22 @@
 import { Helmet } from 'react-helmet'
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 
 function Head() {
+  const { t, i18n } = useTranslation()
+
+  useEffect(() => {
+    document.documentElement.lang = i18n.language
+  }, [i18n.language])
+
   return (
     <Helmet>
+      <title>{t('title_index')}</title>
+      <meta name="description" content={t('hero_subtitle')} />
+      <meta property="og:title" content={t('title_index')} />
+      <meta property="og:description" content={t('hero_subtitle')} />
+      <meta name="twitter:title" content={t('title_index')} />
+      <meta name="twitter:description" content={t('hero_subtitle')} />
       <link rel="icon" type="image/svg+xml" href="/assets/hall-symbol.svg" />
       <link rel="preconnect" href="https://fonts.googleapis.com" />
       <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />


### PR DESCRIPTION
## Summary
- use `react-i18next` in head for page metadata
- set `html` lang attribute on language change

## Testing
- `CI=1 npm test`
- `CI=1 npm test --workspace frontend`
- `npm run lint --workspace frontend`
- `npm run lint` *(fails: bundle.js ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae94bcabb88327aeeec19d68f93a4c