### PR TITLE
Load whitepaper dynamically

### DIFF
--- a/frontend/src/components/Whitepaper.tsx
+++ b/frontend/src/components/Whitepaper.tsx
@@ -1,14 +1,34 @@
-import { Trans } from 'react-i18next'
+import { useEffect, useState } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+import createDOMPurify from 'dompurify'
+
+const DOMPurify = createDOMPurify(window)
 
 function Whitepaper() {
+  const { i18n, t } = useTranslation()
+  const [html, setHtml] = useState<string | null>()
+
+  useEffect(() => {
+    fetch(`whitepaper/${i18n.language}/index.html`)
+      .then((response) => (response.ok ? response.text() : Promise.reject()))
+      .then((data) => {
+        setHtml(DOMPurify.sanitize(data))
+      })
+      .catch(() => {
+        setHtml(null)
+      })
+  }, [i18n.language])
+
   return (
     <section id="whitepaper">
       <h2>
         <Trans i18nKey="nav_whitepaper" />
       </h2>
-      <p>
-        <Trans i18nKey="notice_whitepaper_unavailable" />
-      </p>
+      {html ? (
+        <div dangerouslySetInnerHTML={{ __html: html }} />
+      ) : html === null ? (
+        <p>{t('notice_whitepaper_unavailable')}</p>
+      ) : null}
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- fetch and sanitize localized whitepaper HTML
- show translation fallback when whitepaper unavailable

## Testing
- `npm test`
- `npm test --workspace frontend -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ae99ee5afc83278b6084bec21d6295