### PR TITLE
fix: root-relative links to official site

### DIFF
--- a/whitepaper/ar/index.html
+++ b/whitepaper/ar/index.html
@@ -74,7 +74,7 @@
       <section class="wp-section">
         <h2>المراجع</h2>
         <ul class="icon-list">
-          <li><i class="material-symbols-outlined">public</i><a href="index.html">الموقع الرسمي</a></li>
+          <li><i class="material-symbols-outlined">public</i><a href="../../index.html">الموقع الرسمي</a></li>
           <li><i class="material-symbols-outlined">code</i><a href="https://github.com/hallyu-chain" target="_blank" rel="noopener noreferrer">مستودع GitHub</a></li>
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">مجتمع Discord</a></li>
         </ul>

--- a/whitepaper/de/index.html
+++ b/whitepaper/de/index.html
@@ -74,7 +74,7 @@
       <section class="wp-section">
         <h2>Referenzen</h2>
         <ul class="icon-list">
-          <li><i class="material-symbols-outlined">public</i><a href="index.html">Offizielle Website</a></li>
+          <li><i class="material-symbols-outlined">public</i><a href="../../index.html">Offizielle Website</a></li>
           <li><i class="material-symbols-outlined">code</i><a href="https://github.com/hallyu-chain" target="_blank" rel="noopener noreferrer">GitHub-Repository</a></li>
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Discord-Community</a></li>
         </ul>

--- a/whitepaper/en/index.html
+++ b/whitepaper/en/index.html
@@ -74,7 +74,7 @@
       <section class="wp-section">
         <h2>References</h2>
         <ul class="icon-list">
-          <li><i class="material-symbols-outlined">public</i><a href="index.html">Official Website</a></li>
+          <li><i class="material-symbols-outlined">public</i><a href="../../index.html">Official Website</a></li>
           <li><i class="material-symbols-outlined">code</i><a href="https://github.com/hallyu-chain" target="_blank" rel="noopener noreferrer">GitHub Repository</a></li>
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Discord Community</a></li>
         </ul>

--- a/whitepaper/es/index.html
+++ b/whitepaper/es/index.html
@@ -74,7 +74,7 @@
       <section class="wp-section">
         <h2>Referencias</h2>
         <ul class="icon-list">
-          <li><i class="material-symbols-outlined">public</i><a href="index.html">Sitio web oficial</a></li>
+          <li><i class="material-symbols-outlined">public</i><a href="../../index.html">Sitio web oficial</a></li>
           <li><i class="material-symbols-outlined">code</i><a href="https://github.com/hallyu-chain" target="_blank" rel="noopener noreferrer">Repositorio de GitHub</a></li>
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Comunidad de Discord</a></li>
         </ul>

--- a/whitepaper/fr/index.html
+++ b/whitepaper/fr/index.html
@@ -74,7 +74,7 @@
       <section class="wp-section">
         <h2>Références</h2>
         <ul class="icon-list">
-          <li><i class="material-symbols-outlined">public</i><a href="index.html">Site officiel</a></li>
+          <li><i class="material-symbols-outlined">public</i><a href="../../index.html">Site officiel</a></li>
           <li><i class="material-symbols-outlined">code</i><a href="https://github.com/hallyu-chain" target="_blank" rel="noopener noreferrer">Dépôt GitHub</a></li>
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Communauté Discord</a></li>
         </ul>

--- a/whitepaper/hi/index.html
+++ b/whitepaper/hi/index.html
@@ -74,7 +74,7 @@
       <section class="wp-section">
         <h2>संदर्भ</h2>
         <ul class="icon-list">
-          <li><i class="material-symbols-outlined">public</i><a href="index.html">आधिकारिक वेबसाइट</a></li>
+          <li><i class="material-symbols-outlined">public</i><a href="../../index.html">आधिकारिक वेबसाइट</a></li>
           <li><i class="material-symbols-outlined">code</i><a href="https://github.com/hallyu-chain" target="_blank" rel="noopener noreferrer">GitHub रिपॉजिटरी</a></li>
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Discord समुदाय</a></li>
         </ul>

--- a/whitepaper/ja/index.html
+++ b/whitepaper/ja/index.html
@@ -74,7 +74,7 @@
       <section class="wp-section">
         <h2>参考資料</h2>
         <ul class="icon-list">
-          <li><i class="material-symbols-outlined">public</i><a href="index.html">公式ウェブサイト</a></li>
+          <li><i class="material-symbols-outlined">public</i><a href="../../index.html">公式ウェブサイト</a></li>
           <li><i class="material-symbols-outlined">code</i><a href="https://github.com/hallyu-chain" target="_blank" rel="noopener noreferrer">GitHub リポジトリ</a></li>
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Discord コミュニティ</a></li>
         </ul>

--- a/whitepaper/ko/index.html
+++ b/whitepaper/ko/index.html
@@ -74,7 +74,7 @@
       <section class="wp-section">
         <h2>참고 자료</h2>
         <ul class="icon-list">
-          <li><i class="material-symbols-outlined">public</i><a href="index.html">공식 홈페이지</a></li>
+          <li><i class="material-symbols-outlined">public</i><a href="../../index.html">공식 홈페이지</a></li>
           <li><i class="material-symbols-outlined">code</i><a href="https://github.com/hallyu-chain" target="_blank" rel="noopener noreferrer">GitHub 저장소</a></li>
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Discord 커뮤니티</a></li>
         </ul>

--- a/whitepaper/pt/index.html
+++ b/whitepaper/pt/index.html
@@ -74,7 +74,7 @@
       <section class="wp-section">
         <h2>Referências</h2>
         <ul class="icon-list">
-          <li><i class="material-symbols-outlined">public</i><a href="index.html">Site oficial</a></li>
+          <li><i class="material-symbols-outlined">public</i><a href="../../index.html">Site oficial</a></li>
           <li><i class="material-symbols-outlined">code</i><a href="https://github.com/hallyu-chain" target="_blank" rel="noopener noreferrer">Repositório GitHub</a></li>
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Comunidade Discord</a></li>
         </ul>

--- a/whitepaper/ru/index.html
+++ b/whitepaper/ru/index.html
@@ -74,7 +74,7 @@
       <section class="wp-section">
         <h2>Ссылки</h2>
         <ul class="icon-list">
-          <li><i class="material-symbols-outlined">public</i><a href="index.html">Официальный сайт</a></li>
+          <li><i class="material-symbols-outlined">public</i><a href="../../index.html">Официальный сайт</a></li>
           <li><i class="material-symbols-outlined">code</i><a href="https://github.com/hallyu-chain" target="_blank" rel="noopener noreferrer">Репозиторий GitHub</a></li>
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Сообщество Discord</a></li>
         </ul>

--- a/whitepaper/zh/index.html
+++ b/whitepaper/zh/index.html
@@ -74,7 +74,7 @@
         <section class="wp-section">
           <h2>参考资料</h2>
           <ul class="icon-list">
-            <li><i class="material-symbols-outlined">public</i><a href="index.html">官方网站</a></li>
+            <li><i class="material-symbols-outlined">public</i><a href="../../index.html">官方网站</a></li>
             <li><i class="material-symbols-outlined">code</i><a href="https://github.com/hallyu-chain" target="_blank" rel="noopener noreferrer">GitHub 仓库</a></li>
             <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Discord 社区</a></li>
           </ul>


### PR DESCRIPTION
## Summary
- Update "Official Website" links in all whitepaper translations to use root-relative paths back to the main site

## Testing
- `npm test`
- `npm run lint` *(fails: 20 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aea346c3f0832794d1b11a3f6fc58c