### PR TITLE
Fix partners section markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,18 +405,18 @@
       <div class="logo-grid">
         <div class="logo-item">
           <img src="/assets/music-chain-logo.svg" alt="MusicChain logo" loading="lazy" />
-          <i class="material-symbols-outlined" aria-hidden="true">music_note</i
-          >span data-i18n="partner1">뮤직체인</span>
+          <i class="material-symbols-outlined" aria-hidden="true">music_note</i>
+          <span data-i18n="partner1">뮤직체인</span>
         </div>
         <div class="logo-item">
           <img src="/assets/game-world-logo.svg" alt="GameWorld logo" loading="lazy" />
-          <i class="material-symbols-outlined" aria-hidden="true">sports_esports</i
-          >span data-i18n="partner2">게임월드</span>
+          <i class="material-symbols-outlined" aria-hidden="true">sports_esports</i>
+          <span data-i18n="partner2">게임월드</span>
         </div>
         <div class="logo-item">
           <img src="/assets/entermedia-logo.svg" alt="EnterMedia logo" loading="lazy" />
-          <i class="material-symbols-outlined" aria-hidden="true">movie</i
-          >span data-i18n="partner3">엔터미디어</span>
+          <i class="material-symbols-outlined" aria-hidden="true">movie</i>
+          <span data-i18n="partner3">엔터미디어</span>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- close stray `</i>` tags and properly open `<span>` elements for partner listings

## Testing
- ❌ `npm run lint` (fails: no-useless-escape, etc. in bundle.js)
- ✅ `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeae22e7388327a34ae5d2ecd86fb7