### PR TITLE
fix: align Korean staking wording with locale

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
         </div>
         <div class="card">
           <i class="material-symbols-outlined" aria-hidden="true">token</i>
-          <h3 data-i18n="feat4_title">스테이킹 혜택</h3>
+          <h3 data-i18n="feat4_title">스테이킹 보상</h3>
           <p data-i18n="feat4_text">
             토큰을 스테이킹하면 특별한 보상을 받을 수 있습니다
           </p>


### PR DESCRIPTION
## Summary
- update staking feature heading to use "스테이킹 보상" for Korean text
- ensure staking references use the same wording

## Testing
- `npm test`
- `npm run lint` *(fails: bundle.js lint errors)*
- `npm run check-locales`


------
https://chatgpt.com/codex/tasks/task_e_68aeae2709f88327afd9cdc7f39bf473