### PR TITLE
Ensure hero fills mobile viewport

### DIFF
--- a/frontend/src/components/Hero.module.css
+++ b/frontend/src/components/Hero.module.css
@@ -79,7 +79,8 @@
 
 @media (max-width: 768px) {
   .hero {
-    min-height: calc(100vh - var(--nav-height));
+    min-height: 100vh;
+    min-height: 100svh;
     padding: calc(var(--space-lg) * 3) var(--space-md) calc(var(--space-lg) * 2);
   }
 

--- a/style.css
+++ b/style.css
@@ -604,7 +604,8 @@ body.dark-mode .footer {
     }
 
   .hero {
-    min-height: calc(100vh - var(--nav-height));
+    min-height: 100vh;
+    min-height: 100svh;
     padding: calc(var(--space-lg) * 3) var(--space-md) calc(var(--space-lg) * 2);
   }
 


### PR DESCRIPTION
## Summary
- Use full viewport height for hero on mobile
- Support small viewport height units for better handling of mobile browser chrome

## Testing
- `npm test`
- `npm run lint` *(fails: 23 problems in bundle.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb13042488327ac6b36db7b070cd3