### PR TITLE
feat: support dynamic viewport units

### DIFF
--- a/frontend/src/components/Hero.module.css
+++ b/frontend/src/components/Hero.module.css
@@ -4,11 +4,21 @@
   justify-content: center;
   align-items: center;
   text-align: center;
-  min-height: calc(100vh - var(--nav-height));
+  min-height: calc(100svh - var(--nav-height));
   padding: 0 1rem;
   position: relative;
   overflow: hidden;
   perspective: 800px;
+}
+@supports (min-height: 100dvh) {
+  .hero {
+    min-height: calc(100dvh - var(--nav-height));
+  }
+}
+@supports not (min-height: 100svh) {
+  .hero {
+    min-height: calc(100vh - var(--nav-height));
+  }
 }
 
 .hero::before {
@@ -79,8 +89,19 @@
 
 @media (max-width: 768px) {
   .hero {
-    min-height: calc(100vh - var(--nav-height));
+    min-height: calc(100svh - var(--nav-height));
     padding: calc(var(--space-lg) * 3) var(--space-md) calc(var(--space-lg) * 2);
+  }
+
+  @supports (min-height: 100dvh) {
+    .hero {
+      min-height: calc(100dvh - var(--nav-height));
+    }
+  }
+  @supports not (min-height: 100svh) {
+    .hero {
+      min-height: calc(100vh - var(--nav-height));
+    }
   }
 
   .btn {

--- a/style.css
+++ b/style.css
@@ -184,13 +184,23 @@ body {
   justify-content: center;
   align-items: center;
   text-align: center;
-  min-height: calc(100vh - var(--nav-height));
+  min-height: calc(100svh - var(--nav-height));
   padding: 0 1rem;
   position: relative;
   overflow: hidden;
   perspective: 800px;
   background-color: #000;
   color: var(--fg);
+}
+@supports (min-height: 100dvh) {
+  .hero {
+    min-height: calc(100dvh - var(--nav-height));
+  }
+}
+@supports not (min-height: 100svh) {
+  .hero {
+    min-height: calc(100vh - var(--nav-height));
+  }
 }
 
 .hero-media {
@@ -604,8 +614,19 @@ body.dark-mode .footer {
     }
 
   .hero {
-    min-height: calc(100vh - var(--nav-height));
+    min-height: calc(100svh - var(--nav-height));
     padding: calc(var(--space-lg) * 3) var(--space-md) calc(var(--space-lg) * 2);
+  }
+
+  @supports (min-height: 100dvh) {
+    .hero {
+      min-height: calc(100dvh - var(--nav-height));
+    }
+  }
+  @supports not (min-height: 100svh) {
+    .hero {
+      min-height: calc(100vh - var(--nav-height));
+    }
   }
 
   section {


### PR DESCRIPTION
## Summary
- switch hero sections to use dynamic viewport units for mobile browser compatibility
- add `@supports` fallbacks so browsers without `svh`/`dvh` still render correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeb1333ee88327b4035175947e9e4d