### PR TITLE
Adjust nav height handling for mobile layouts

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -69,11 +69,20 @@ html {
     --space-sm: 0.75rem;
     --space-md: 1.25rem;
     --space-lg: 1.75rem;
+    --nav-height: 0px;
   }
 
   html,
   body {
     font-size: 16px;
     line-height: 1.8;
+  }
+
+  body {
+    padding-top: 0;
+  }
+
+  html {
+    scroll-padding-top: 0;
   }
 }

--- a/frontend/src/hooks/useNavHeight.ts
+++ b/frontend/src/hooks/useNavHeight.ts
@@ -6,9 +6,12 @@ export function useNavHeight(ref: React.RefObject<HTMLElement>) {
       const nav = ref.current
       if (!nav) return
       const height = nav.getBoundingClientRect().height
-      document.documentElement.style.setProperty('--nav-height', `${height}px`)
-      document.documentElement.style.scrollPaddingTop = `${height}px`
-      document.body.style.paddingTop = `${height}px`
+      const { position } = window.getComputedStyle(nav)
+      const fixed = position === 'fixed' || window.innerWidth > 768
+      const value = fixed ? `${height}px` : '0px'
+      document.documentElement.style.setProperty('--nav-height', value)
+      document.documentElement.style.scrollPaddingTop = value
+      document.body.style.paddingTop = value
     }
     update()
     window.addEventListener('resize', update)

--- a/src/nav.ts
+++ b/src/nav.ts
@@ -3,9 +3,12 @@ export function initNav() {
     const navbar = document.querySelector('.navbar');
     if (!navbar) return;
     const height = navbar.getBoundingClientRect().height;
-    document.documentElement.style.setProperty('--nav-height', `${height}px`);
-    document.documentElement.style.scrollPaddingTop = `${height}px`;
-    document.body.style.paddingTop = `${height}px`;
+    const { position } = window.getComputedStyle(navbar);
+    const fixed = position === 'fixed' || window.innerWidth > 768;
+    const value = fixed ? `${height}px` : '0px';
+    document.documentElement.style.setProperty('--nav-height', value);
+    document.documentElement.style.scrollPaddingTop = value;
+    document.body.style.paddingTop = value;
   }
 
   updateNavHeight();

--- a/style.css
+++ b/style.css
@@ -570,11 +570,20 @@ body.dark-mode .footer {
     --space-sm: 0.75rem;
     --space-md: 1.25rem;
     --space-lg: 1.75rem;
+    --nav-height: 0px;
   }
 
   html, body {
     font-size: 16px;
     line-height: 1.8;
+  }
+
+  body {
+    padding-top: 0;
+  }
+
+  html {
+    scroll-padding-top: 0;
   }
 
     .navbar {


### PR DESCRIPTION
## Summary
- Reset body padding and scroll-padding on small screens in global styles
- Apply nav padding only when navbar is fixed or on desktop widths
- Default --nav-height to 0px for mobile to avoid double spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeb3101d848327a8fdc7b95a6dc04d