### PR TITLE
Respect reduced motion for smooth scrolling

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -60,8 +60,19 @@ body[data-theme='dark'] {
 }
 
 html {
-  scroll-behavior: smooth;
   scroll-padding-top: var(--nav-height);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
 }
 
 @media (max-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -78,8 +78,19 @@ html, body {
 }
 
 html {
-  scroll-behavior: smooth;
   scroll-padding-top: var(--nav-height);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
 }
 
 body {


### PR DESCRIPTION
## Summary
- Wrap scroll-behavior rules in prefers-reduced-motion media queries
- Default to smooth scrolling only when reduced motion is not preferred
- Ensure reduced motion preference uses auto scrolling

## Testing
- `npm test`
- `npm run lint` *(fails: 23 problems in bundle.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb8a81114832792e6029004ee702e