### PR TITLE
Add safe-area inset support

### DIFF
--- a/frontend/src/components/BackToTop.module.css
+++ b/frontend/src/components/BackToTop.module.css
@@ -1,7 +1,7 @@
 .backToTop {
   position: fixed;
-  bottom: var(--space-lg);
-  right: var(--space-lg);
+  bottom: calc(var(--space-lg) + env(safe-area-inset-bottom, 0));
+  right: calc(var(--space-lg) + env(safe-area-inset-right, 0));
   width: 3rem;
   height: 3rem;
   border: none;

--- a/frontend/src/components/NoticeProvider.module.css
+++ b/frontend/src/components/NoticeProvider.module.css
@@ -1,6 +1,6 @@
 .notice {
   position: fixed;
-  bottom: 1rem;
+  bottom: calc(1rem + env(safe-area-inset-bottom, 0));
   left: 50%;
   transform: translateX(-50%);
   background: var(--fg);

--- a/style.css
+++ b/style.css
@@ -78,7 +78,7 @@ html, body {
 }
 
 html {
-  scroll-padding-top: var(--nav-height);
+  scroll-padding-top: calc(var(--nav-height) + env(safe-area-inset-top, 0));
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -94,18 +94,22 @@ html {
 }
 
 body {
-  padding-top: var(--nav-height);
+  padding-top: calc(var(--nav-height) + env(safe-area-inset-top, 0));
+  padding-left: env(safe-area-inset-left, 0);
+  padding-right: env(safe-area-inset-right, 0);
+  padding-bottom: env(safe-area-inset-bottom, 0);
 }
 
 .navbar {
   position: fixed;
-  top: 0;
+  top: calc(0px + env(safe-area-inset-top, 0));
   left: 0;
   width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--space-sm) var(--space-lg);
+  padding: var(--space-sm) calc(var(--space-lg) + env(safe-area-inset-right, 0))
+    var(--space-sm) calc(var(--space-lg) + env(safe-area-inset-left, 0));
   background: var(--surface);
   backdrop-filter: blur(5px);
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
@@ -507,8 +511,8 @@ ul, ol {
 
   .back-to-top {
     position: fixed;
-    bottom: var(--space-lg);
-    right: var(--space-lg);
+    bottom: calc(var(--space-lg) + env(safe-area-inset-bottom, 0));
+    right: calc(var(--space-lg) + env(safe-area-inset-right, 0));
     width: 3rem;
     height: 3rem;
     border: none;
@@ -590,17 +594,18 @@ body.dark-mode .footer {
   }
 
   body {
-    padding-top: 0;
+    padding-top: env(safe-area-inset-top, 0);
   }
 
   html {
-    scroll-padding-top: 0;
+    scroll-padding-top: env(safe-area-inset-top, 0);
   }
 
     .navbar {
       flex-wrap: wrap;
       align-items: center;
-      padding: var(--space-md);
+      padding: var(--space-md) calc(var(--space-md) + env(safe-area-inset-right, 0))
+        var(--space-md) calc(var(--space-md) + env(safe-area-inset-left, 0));
       position: relative;
     }
 
@@ -671,7 +676,7 @@ body.dark-mode .footer {
 
 .notice {
   position: fixed;
-  bottom: 1rem;
+  bottom: calc(1rem + env(safe-area-inset-bottom, 0));
   left: 50%;
   transform: translateX(-50%);
   background: var(--fg);


### PR DESCRIPTION
## Summary
- respect safe-area insets for body and navbar to avoid notch overlap
- offset BackToTop and notifications by platform-specific safe-area paddings
- include horizontal safe-area padding for nav and floating elements

## Testing
- `npm test`
- `npm test --workspace frontend -- --run`
- `npm run lint` *(fails: Unnecessary escape character \-, etc. in bundle.js)*
- `npm run lint --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_68aeb95ebd888327a54c88455e619f58