### PR TITLE
Normalize root font size to 100%

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -43,7 +43,7 @@ body {
   background: var(--bg);
   color: var(--fg);
   font-family: 'Roboto', sans-serif;
-  font-size: 15px;
+  font-size: 100%;
   line-height: 1.6;
   padding-top: var(--nav-height);
   color-scheme: light;
@@ -85,7 +85,7 @@ html {
 
   html,
   body {
-    font-size: 16px;
+    font-size: 100%;
     line-height: 1.8;
   }
 

--- a/style.css
+++ b/style.css
@@ -84,7 +84,7 @@ body {
   background: var(--bg);
   color: var(--fg);
   font-family: 'Roboto', sans-serif;
-  font-size: 15px;
+  font-size: 100%;
   line-height: 1.6;
 }
 
@@ -624,7 +624,7 @@ body.dark-mode .footer {
 
   html,
   body {
-    font-size: 16px;
+    font-size: 100%;
     line-height: 1.8;
   }
 


### PR DESCRIPTION
## Summary
- use `font-size: 100%` for base html/body styles
- keep responsive styles with 100% font sizing at max-width 768px

## Testing
- `npm test`
- `npm run lint` *(fails: Definition for rule 'unicorn/prefer-includes' not found and other errors in bundle.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aec755f9048327bf5362c9b30a70a0