### PR TITLE
Fix mobile nav height for mobile layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -619,7 +619,7 @@ body.dark-mode .footer {
     --space-sm: 0.75rem;
     --space-md: 1.25rem;
     --space-lg: 1.75rem;
-    --nav-height: 0px;
+    --nav-height: 60px;
   }
 
   html,
@@ -629,11 +629,11 @@ body.dark-mode .footer {
   }
 
   body {
-    padding-top: env(safe-area-inset-top, 0);
+    padding-top: calc(var(--nav-height) + env(safe-area-inset-top, 0));
   }
 
   html {
-    scroll-padding-top: env(safe-area-inset-top, 0);
+    scroll-padding-top: calc(var(--nav-height) + env(safe-area-inset-top, 0));
   }
 
   .navbar {


### PR DESCRIPTION
## Summary
- use actual mobile nav height and adjust padding

## Testing
- `npm test`
- Headless mobile Chromium check of `.hero` min-height

------
https://chatgpt.com/codex/tasks/task_e_68af9b8602908327ad1c5f9b681cda33