### PR TITLE
Adjust hero min-height for safe area

### DIFF
--- a/style.css
+++ b/style.css
@@ -232,7 +232,9 @@ body {
   justify-content: center;
   align-items: center;
   text-align: center;
-  min-height: calc(100svh - var(--nav-height));
+  min-height: calc(
+    100svh - var(--nav-height) - env(safe-area-inset-bottom, 0)
+  );
   padding: 0 1rem;
   position: relative;
   overflow: hidden;
@@ -242,12 +244,16 @@ body {
 }
 @supports (min-height: 100dvh) {
   .hero {
-    min-height: calc(100dvh - var(--nav-height));
+    min-height: calc(
+      100dvh - var(--nav-height) - env(safe-area-inset-bottom, 0)
+    );
   }
 }
 @supports not (min-height: 100svh) {
   .hero {
-    min-height: calc(100vh - var(--nav-height));
+    min-height: calc(
+      100vh - var(--nav-height) - env(safe-area-inset-bottom, 0)
+    );
   }
 }
 
@@ -693,18 +699,24 @@ body.dark-mode .footer {
   }
 
   .hero {
-    min-height: calc(100svh - var(--nav-height));
+    min-height: calc(
+      100svh - var(--nav-height) - env(safe-area-inset-bottom, 0)
+    );
     padding: calc(var(--space-lg) * 3) var(--space-md) calc(var(--space-lg) * 2);
   }
 
   @supports (min-height: 100dvh) {
     .hero {
-      min-height: calc(100dvh - var(--nav-height));
+      min-height: calc(
+        100dvh - var(--nav-height) - env(safe-area-inset-bottom, 0)
+      );
     }
   }
   @supports not (min-height: 100svh) {
     .hero {
-      min-height: calc(100vh - var(--nav-height));
+      min-height: calc(
+        100vh - var(--nav-height) - env(safe-area-inset-bottom, 0)
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- account for mobile safe area insets in hero min-height calculations for svh, dvh, and fallback vh units

## Testing
- `npm test`
- `npm run lint` *(fails: Definition for rule 'unicorn/prefer-includes' was not found, '_' is defined but never used, Empty block statement, Expected a conditional expression and instead saw an assignment)*

------
https://chatgpt.com/codex/tasks/task_e_68afa24054a88327b8031eea9aa0da4c