### PR TITLE
Remove extra top padding on narrow screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -651,11 +651,11 @@ body.dark-mode .footer {
   }
 
   body {
-    padding-top: calc(var(--nav-height) + env(safe-area-inset-top, 0));
+    padding-top: env(safe-area-inset-top, 0);
   }
 
   html {
-    scroll-padding-top: calc(var(--nav-height) + env(safe-area-inset-top, 0));
+    scroll-padding-top: env(safe-area-inset-top, 0);
   }
 
   .navbar {


### PR DESCRIPTION
## Summary
- prevent body padding from including navbar height on mobile
- adjust scroll padding to match safe-area inset only

## Testing
- `npm test`
- `npm run lint` *(fails: issues in bundle.js)*

------
https://chatgpt.com/codex/tasks/task_e_68afa6efbcf48327bb6686c2aeb8c9e2