### PR TITLE
Add staking progress card and localization

### DIFF
--- a/index.html
+++ b/index.html
@@ -462,14 +462,23 @@
 
     <section id="staking">
       <h2 data-i18n="staking_title">Staking & Rewards</h2>
-      <p>
-        <span data-i18n="staking_total">Total Staked:</span>
-        <span id="total-staked">-</span>
-      </p>
-      <p>
-        <span data-i18n="staking_rewards">Your Rewards:</span>
-        <span id="user-rewards">-</span>
-      </p>
+      <div class="staking-card">
+        <p>
+          <span data-i18n="staking_total">Total Staked:</span>
+          <span id="total-staked">-</span>
+        </p>
+        <p>
+          <span data-i18n="staking_rewards">Your Rewards:</span>
+          <span id="user-rewards">-</span>
+        </p>
+        <p>
+          <span data-i18n="staking_percent">Network Staked:</span>
+          <span id="staking-percent">-</span>
+        </p>
+        <div class="staking-progress">
+          <div id="staking-progress-bar"></div>
+        </div>
+      </div>
       <p id="staking-error" class="error" hidden></p>
     </section>
 

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -116,6 +116,7 @@
   "staking_title": "التخزين والمكافآت",
   "staking_total": "إجمالي التخزين",
   "staking_rewards": "مكافآتك",
+  "staking_percent": "نسبة التخزين",
   "notice_load_fail": "فشل تحميل الترجمة.",
   "notice_lang_unavailable": "اللغة المختارة غير متاحة. سيتم استخدام اللغة الافتراضية.",
   "notice_whitepaper_unavailable": "الورقة البيضاء غير متاحة.",

--- a/locales/de.json
+++ b/locales/de.json
@@ -116,6 +116,7 @@
   "staking_title": "Staking & Belohnungen",
   "staking_total": "Gesamt gestaket",
   "staking_rewards": "Deine Belohnungen",
+  "staking_percent": "Staking-Prozentsatz",
   "notice_load_fail": "Lokalisierung konnte nicht geladen werden.",
   "notice_lang_unavailable": "Ausgewählte Sprache nicht verfügbar. Standardsprache wird verwendet.",
   "notice_whitepaper_unavailable": "Whitepaper nicht verfügbar.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -116,6 +116,7 @@
   "staking_title": "Staking & Rewards",
   "staking_total": "Total Staked",
   "staking_rewards": "Your Rewards",
+  "staking_percent": "Network Staked",
   "notice_load_fail": "Localization failed to load.",
   "notice_lang_unavailable": "Selected language unavailable. Using default language.",
   "notice_whitepaper_unavailable": "Whitepaper not available.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -116,6 +116,7 @@
   "staking_title": "Staking y Recompensas",
   "staking_total": "Total Acumulado",
   "staking_rewards": "Tus Recompensas",
+  "staking_percent": "Porcentaje de staking",
   "notice_load_fail": "No se pudo cargar la localización.",
   "notice_lang_unavailable": "El idioma seleccionado no está disponible. Se usará el idioma predeterminado.",
   "notice_whitepaper_unavailable": "Libro blanco no disponible.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -116,6 +116,7 @@
   "staking_title": "Staking et Récompenses",
   "staking_total": "Total Staké",
   "staking_rewards": "Vos Récompenses",
+  "staking_percent": "Pourcentage de staking",
   "notice_load_fail": "Échec du chargement de la localisation.",
   "notice_lang_unavailable": "Langue sélectionnée indisponible. Utilisation de la langue par défaut.",
   "notice_whitepaper_unavailable": "Livre blanc non disponible.",

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -116,6 +116,7 @@
   "staking_title": "स्टेकिंग और रिवॉर्ड",
   "staking_total": "कुल स्टेक",
   "staking_rewards": "आपके रिवॉर्ड",
+  "staking_percent": "स्टेकिंग प्रतिशत",
   "notice_load_fail": "स्थानीयकरण लोड करने में विफल।",
   "notice_lang_unavailable": "चयनित भाषा उपलब्ध नहीं है। डिफ़ॉल्ट भाषा का उपयोग किया जाएगा।",
   "notice_whitepaper_unavailable": "श्वेतपत्र उपलब्ध नहीं है।",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -116,6 +116,7 @@
   "staking_title": "ステーキングと報酬",
   "staking_total": "総ステーク量",
   "staking_rewards": "あなたの報酬",
+  "staking_percent": "ステーキング割合",
   "notice_load_fail": "ローカライゼーションの読み込みに失敗しました。",
   "notice_lang_unavailable": "選択した言語は利用できません。デフォルトの言語を使用します。",
   "notice_whitepaper_unavailable": "ホワイトペーパーは利用できません。",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -116,6 +116,7 @@
   "staking_title": "스테이킹 및 리워드",
   "staking_total": "총 스테이킹",
   "staking_rewards": "내 보상",
+  "staking_percent": "네트워크 스테이킹 비율",
   "notice_load_fail": "로컬라이제이션을 불러오지 못했습니다.",
   "notice_lang_unavailable": "선택한 언어를 사용할 수 없습니다. 기본 언어로 표시됩니다.",
   "notice_whitepaper_unavailable": "백서를 사용할 수 없습니다.",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -116,6 +116,7 @@
   "staking_title": "Staking e Recompensas",
   "staking_total": "Total em Staking",
   "staking_rewards": "Suas Recompensas",
+  "staking_percent": "Percentual de staking",
   "notice_load_fail": "Falha ao carregar a localização.",
   "notice_lang_unavailable": "Idioma selecionado indisponível. Usando o idioma padrão.",
   "notice_whitepaper_unavailable": "Whitepaper indisponível.",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -116,6 +116,7 @@
   "staking_title": "Стейкинг и награды",
   "staking_total": "Всего застейкано",
   "staking_rewards": "Ваши награды",
+  "staking_percent": "Процент стейкинга",
   "notice_load_fail": "Не удалось загрузить локализацию.",
   "notice_lang_unavailable": "Выбранный язык недоступен. Используется язык по умолчанию.",
   "notice_whitepaper_unavailable": "Whitepaper недоступен.",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -116,6 +116,7 @@
   "staking_title": "质押与奖励",
   "staking_total": "总质押量",
   "staking_rewards": "你的奖励",
+  "staking_percent": "质押百分比",
   "notice_load_fail": "加载本地化失败。",
   "notice_lang_unavailable": "所选语言不可用，已使用默认语言。",
   "notice_whitepaper_unavailable": "白皮书不可用。",

--- a/src/staking.test.ts
+++ b/src/staking.test.ts
@@ -3,15 +3,17 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import { loadStakingStatus, fetchStakingData } from './staking.ts';
 
-const dom = new JSDOM('<!doctype html><body><span id="total-staked"></span><span id="user-rewards"></span><div id="staking-error" hidden></div></body>', { url: 'http://localhost' });
+const dom = new JSDOM('<!doctype html><body><span id="total-staked"></span><span id="user-rewards"></span><span id="staking-percent"></span><div class="staking-progress"><div id="staking-progress-bar"></div></div><div id="staking-error" hidden></div></body>', { url: 'http://localhost' });
 global.window = dom.window;
 global.document = dom.window.document;
 
 test('loadStakingStatus populates elements', async () => {
-  global.fetch = async () => ({ ok: true, json: async () => ({ totalStaked: '100', userRewards: '5' }) });
+  global.fetch = async () => ({ ok: true, json: async () => ({ totalStaked: '100', userRewards: '5', totalSupply: '200' }) });
   await loadStakingStatus();
   assert.equal(document.getElementById('total-staked').textContent, '100');
   assert.equal(document.getElementById('user-rewards').textContent, '5');
+  assert.equal(document.getElementById('staking-percent').textContent, '50.00%');
+  assert.equal(document.getElementById('staking-progress-bar').style.width, '50%');
 });
 
 test('loadStakingStatus shows error on failure', async () => {
@@ -19,6 +21,8 @@ test('loadStakingStatus shows error on failure', async () => {
   await loadStakingStatus();
   assert.equal(document.getElementById('total-staked').textContent, 'N/A');
   assert.equal(document.getElementById('user-rewards').textContent, 'N/A');
+  assert.equal(document.getElementById('staking-percent').textContent, 'N/A');
+  assert.equal(document.getElementById('staking-progress-bar').style.width, '0%');
   const err = document.getElementById('staking-error');
   assert.equal(err.hidden, false);
   assert.equal(err.textContent, 'Failed to load staking info.');

--- a/src/staking.ts
+++ b/src/staking.ts
@@ -8,14 +8,24 @@ export async function loadStakingStatus(fetchFn = fetch) {
   const total = document.getElementById('total-staked');
   const rewards = document.getElementById('user-rewards');
   const errorEl = document.getElementById('staking-error');
+  const percentEl = document.getElementById('staking-percent');
+  const progressBar = document.getElementById('staking-progress-bar');
   try {
     const data = await fetchStakingData(fetchFn);
     if (total) total.textContent = data.totalStaked;
     if (rewards) rewards.textContent = data.userRewards;
+    const percent =
+      data.totalSupply
+        ? (Number(data.totalStaked) / Number(data.totalSupply)) * 100
+        : Number(data.stakingPercent ?? 0);
+    if (percentEl) percentEl.textContent = `${percent.toFixed(2)}%`;
+    if (progressBar) progressBar.style.width = `${percent}%`;
   } catch (err) {
     console.error('Failed to fetch staking info', err);
     if (total) total.textContent = 'N/A';
     if (rewards) rewards.textContent = 'N/A';
+    if (percentEl) percentEl.textContent = 'N/A';
+    if (progressBar) progressBar.style.width = '0%';
     if (errorEl) {
       errorEl.textContent = 'Failed to load staking info.';
       errorEl.hidden = false;

--- a/style.css
+++ b/style.css
@@ -800,3 +800,26 @@ body.dark-mode .footer {
 .error {
   color: red;
 }
+
+.staking-card {
+  background: var(--surface);
+  padding: var(--space-md);
+  border-radius: 8px;
+  max-width: 400px;
+  margin: var(--space-md) auto;
+}
+
+.staking-progress {
+  background: var(--surface);
+  border-radius: 4px;
+  height: 1rem;
+  overflow: hidden;
+  margin-top: var(--space-sm);
+}
+
+.staking-progress > div {
+  background: var(--accent);
+  height: 100%;
+  width: 0%;
+  transition: width 0.3s ease;
+}


### PR DESCRIPTION
## Summary
- Wrap staking totals in a card and display network staking percentage with a progress bar
- Style staking card and progress bar for visual feedback
- Compute staking percentage in `staking.ts` and localize new label across all locales

## Testing
- `npm test`
- `npm run lint` *(fails: unicorn/prefer-includes rule not found and unused vars, etc.)*
- `npm run check-locales`


------
https://chatgpt.com/codex/tasks/task_e_68afbe2a7ce48327ad587ed8f9e5fcdd