### PR TITLE
Use i18n for staking error messages

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -117,6 +117,8 @@
   "staking_total": "إجمالي التخزين",
   "staking_rewards": "مكافآتك",
   "staking_percent": "نسبة التخزين",
+  "staking_unavailable": "N/A",
+  "staking_error_unavailable": "Failed to load staking info.",
   "notice_load_fail": "فشل تحميل الترجمة.",
   "notice_lang_unavailable": "اللغة المختارة غير متاحة. سيتم استخدام اللغة الافتراضية.",
   "notice_whitepaper_unavailable": "الورقة البيضاء غير متاحة.",

--- a/locales/de.json
+++ b/locales/de.json
@@ -117,6 +117,8 @@
   "staking_total": "Gesamt gestaket",
   "staking_rewards": "Deine Belohnungen",
   "staking_percent": "Staking-Prozentsatz",
+  "staking_unavailable": "N/A",
+  "staking_error_unavailable": "Failed to load staking info.",
   "notice_load_fail": "Lokalisierung konnte nicht geladen werden.",
   "notice_lang_unavailable": "Ausgewählte Sprache nicht verfügbar. Standardsprache wird verwendet.",
   "notice_whitepaper_unavailable": "Whitepaper nicht verfügbar.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -117,6 +117,8 @@
   "staking_total": "Total Staked",
   "staking_rewards": "Your Rewards",
   "staking_percent": "Network Staked",
+  "staking_unavailable": "N/A",
+  "staking_error_unavailable": "Failed to load staking info.",
   "notice_load_fail": "Localization failed to load.",
   "notice_lang_unavailable": "Selected language unavailable. Using default language.",
   "notice_whitepaper_unavailable": "Whitepaper not available.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -117,6 +117,8 @@
   "staking_total": "Total Acumulado",
   "staking_rewards": "Tus Recompensas",
   "staking_percent": "Porcentaje de staking",
+  "staking_unavailable": "N/A",
+  "staking_error_unavailable": "Failed to load staking info.",
   "notice_load_fail": "No se pudo cargar la localización.",
   "notice_lang_unavailable": "El idioma seleccionado no está disponible. Se usará el idioma predeterminado.",
   "notice_whitepaper_unavailable": "Libro blanco no disponible.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -117,6 +117,8 @@
   "staking_total": "Total Staké",
   "staking_rewards": "Vos Récompenses",
   "staking_percent": "Pourcentage de staking",
+  "staking_unavailable": "N/A",
+  "staking_error_unavailable": "Failed to load staking info.",
   "notice_load_fail": "Échec du chargement de la localisation.",
   "notice_lang_unavailable": "Langue sélectionnée indisponible. Utilisation de la langue par défaut.",
   "notice_whitepaper_unavailable": "Livre blanc non disponible.",

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -117,6 +117,8 @@
   "staking_total": "कुल स्टेक",
   "staking_rewards": "आपके रिवॉर्ड",
   "staking_percent": "स्टेकिंग प्रतिशत",
+  "staking_unavailable": "N/A",
+  "staking_error_unavailable": "Failed to load staking info.",
   "notice_load_fail": "स्थानीयकरण लोड करने में विफल।",
   "notice_lang_unavailable": "चयनित भाषा उपलब्ध नहीं है। डिफ़ॉल्ट भाषा का उपयोग किया जाएगा।",
   "notice_whitepaper_unavailable": "श्वेतपत्र उपलब्ध नहीं है।",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -117,6 +117,8 @@
   "staking_total": "総ステーク量",
   "staking_rewards": "あなたの報酬",
   "staking_percent": "ステーキング割合",
+  "staking_unavailable": "N/A",
+  "staking_error_unavailable": "Failed to load staking info.",
   "notice_load_fail": "ローカライゼーションの読み込みに失敗しました。",
   "notice_lang_unavailable": "選択した言語は利用できません。デフォルトの言語を使用します。",
   "notice_whitepaper_unavailable": "ホワイトペーパーは利用できません。",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -117,6 +117,8 @@
   "staking_total": "총 스테이킹",
   "staking_rewards": "내 보상",
   "staking_percent": "네트워크 스테이킹 비율",
+  "staking_unavailable": "N/A",
+  "staking_error_unavailable": "Failed to load staking info.",
   "notice_load_fail": "로컬라이제이션을 불러오지 못했습니다.",
   "notice_lang_unavailable": "선택한 언어를 사용할 수 없습니다. 기본 언어로 표시됩니다.",
   "notice_whitepaper_unavailable": "백서를 사용할 수 없습니다.",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -117,6 +117,8 @@
   "staking_total": "Total em Staking",
   "staking_rewards": "Suas Recompensas",
   "staking_percent": "Percentual de staking",
+  "staking_unavailable": "N/A",
+  "staking_error_unavailable": "Failed to load staking info.",
   "notice_load_fail": "Falha ao carregar a localização.",
   "notice_lang_unavailable": "Idioma selecionado indisponível. Usando o idioma padrão.",
   "notice_whitepaper_unavailable": "Whitepaper indisponível.",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -117,6 +117,8 @@
   "staking_total": "Всего застейкано",
   "staking_rewards": "Ваши награды",
   "staking_percent": "Процент стейкинга",
+  "staking_unavailable": "N/A",
+  "staking_error_unavailable": "Failed to load staking info.",
   "notice_load_fail": "Не удалось загрузить локализацию.",
   "notice_lang_unavailable": "Выбранный язык недоступен. Используется язык по умолчанию.",
   "notice_whitepaper_unavailable": "Whitepaper недоступен.",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -117,6 +117,8 @@
   "staking_total": "总质押量",
   "staking_rewards": "你的奖励",
   "staking_percent": "质押百分比",
+  "staking_unavailable": "N/A",
+  "staking_error_unavailable": "Failed to load staking info.",
   "notice_load_fail": "加载本地化失败。",
   "notice_lang_unavailable": "所选语言不可用，已使用默认语言。",
   "notice_whitepaper_unavailable": "白皮书不可用。",

--- a/src/staking.test.ts
+++ b/src/staking.test.ts
@@ -1,11 +1,18 @@
 import { JSDOM } from 'jsdom';
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { loadStakingStatus, fetchStakingData } from './staking.ts';
 
 const dom = new JSDOM('<!doctype html><body><span id="total-staked"></span><span id="user-rewards"></span><span id="staking-percent"></span><div class="staking-progress"><div id="staking-progress-bar"></div></div><div id="staking-error" hidden></div></body>', { url: 'http://localhost' });
 global.window = dom.window;
 global.document = dom.window.document;
+global.localStorage = dom.window.localStorage;
+
+const { loadStakingStatus, fetchStakingData } = await import('./staking.ts');
+const { translations } = await import('./i18n.ts');
+translations.en = {
+  staking_unavailable: 'N/A',
+  staking_error_unavailable: 'Failed to load staking info.',
+};
 
 test('loadStakingStatus populates elements', async () => {
   global.fetch = async () => ({ ok: true, json: async () => ({ totalStaked: '100', userRewards: '5', totalSupply: '200' }) });

--- a/src/staking.ts
+++ b/src/staking.ts
@@ -1,3 +1,5 @@
+import { translate } from './i18n.ts';
+
 export async function fetchStakingData(fetchFn = fetch, url = 'staking.json') {
   const resp = await fetchFn(url);
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
@@ -22,12 +24,12 @@ export async function loadStakingStatus(fetchFn = fetch) {
     if (progressBar) progressBar.style.width = `${percent}%`;
   } catch (err) {
     console.error('Failed to fetch staking info', err);
-    if (total) total.textContent = 'N/A';
-    if (rewards) rewards.textContent = 'N/A';
-    if (percentEl) percentEl.textContent = 'N/A';
+    if (total) total.textContent = translate('staking_unavailable');
+    if (rewards) rewards.textContent = translate('staking_unavailable');
+    if (percentEl) percentEl.textContent = translate('staking_unavailable');
     if (progressBar) progressBar.style.width = '0%';
     if (errorEl) {
-      errorEl.textContent = 'Failed to load staking info.';
+      errorEl.textContent = translate('staking_error_unavailable');
       errorEl.hidden = false;
     }
   }


### PR DESCRIPTION
## Summary
- add `staking_unavailable` and `staking_error_unavailable` keys to all locale JSON files
- use `translate` for staking fallback text instead of hard‑coded strings
- load i18n translations in staking tests

## Testing
- `npm run build:web`
- `npm run check-locales`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afd442786c832792eeaed8a604e6a3